### PR TITLE
V3 beta8

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ kotlin.version=2.0.20
 # When updating the version, please as well consider:
 # - here-naksha-lib-core/NakshaVersion (static property: latest)
 # - here-naksha-app-service/src/main/resources/swagger/openapi.yaml (info.version property)
-version=3.0.0-beta.7
+version=3.0.0-beta.8
 
 org.gradle.jvmargs=-Xmx12g
 kotlin.code.style=official

--- a/here-naksha-lib-geo/src/jsMain/kotlin/naksha/geo/GeoUtil.js.kt
+++ b/here-naksha-lib-geo/src/jsMain/kotlin/naksha/geo/GeoUtil.js.kt
@@ -34,6 +34,7 @@ actual class GeoUtil private actual constructor() {
          * @return the GeoJSON geometry.
          * @since 3.0.0
          */
+        @JsStatic
         actual fun fromTWKB(raw: ByteArray?): SpGeometry? {
             if (raw == null) return null
             browserForbidden("fromTWKB")
@@ -47,6 +48,7 @@ actual class GeoUtil private actual constructor() {
          * @return the GeoJSON geometry.
          * @since 3.0.0
          */
+        @JsStatic
         actual fun fromEWKB(raw: ByteArray?): SpGeometry? {
             if (raw == null) return null
             browserForbidden("fromEWKB")
@@ -60,6 +62,7 @@ actual class GeoUtil private actual constructor() {
          * @return the GeoJSON geometry.
          * @since 3.0.0
          */
+        @JsStatic
         actual fun fromWKB(raw: ByteArray?): SpGeometry? {
             if (raw == null) return null
             browserForbidden("fromWKB")
@@ -73,6 +76,7 @@ actual class GeoUtil private actual constructor() {
          * @return the encoded GeoJSON geometry.
          * @since 3.0.0
          */
+        @JsStatic
         actual fun toTWKB(geometry: SpGeometry?): ByteArray? {
             if (geometry == null) return null
             browserForbidden("toTWKB")
@@ -86,6 +90,7 @@ actual class GeoUtil private actual constructor() {
          * @return the encoded GeoJSON geometry.
          * @since 3.0.0
          */
+        @JsStatic
         actual fun toEWKB(geometry: SpGeometry?): ByteArray? {
             if (geometry == null) return null
             browserForbidden("toEWKB")
@@ -99,6 +104,7 @@ actual class GeoUtil private actual constructor() {
          * @return the encoded GeoJSON geometry.
          * @since 3.0.0
          */
+        @JsStatic
         actual fun toWKB(geometry: SpGeometry?): ByteArray? {
             if (geometry == null) return null
             browserForbidden("toWKB")

--- a/here-naksha-lib-geo/src/jvmMain/kotlin/naksha/geo/GeoUtil.jvm.kt
+++ b/here-naksha-lib-geo/src/jvmMain/kotlin/naksha/geo/GeoUtil.jvm.kt
@@ -41,6 +41,7 @@ actual class GeoUtil private actual constructor() {
          * @param jtsGeometry - JTS [GeometryCollection]
          * @return [SpGeometryCollection]
          */
+        @JvmStatic
         fun toGeometryCollection(jtsGeometry: GeometryCollection): SpGeometryCollection {
             val geometries = SpGeometryList()
             for (i in 0..<jtsGeometry.numGeometries) {
@@ -423,6 +424,7 @@ actual class GeoUtil private actual constructor() {
          * @return the GeoJSON geometry.
          * @since 3.0.0
          */
+        @JvmStatic
         actual fun fromTWKB(raw: ByteArray?): SpGeometry? {
             if (raw == null) return null
             val reader = TWKBReader(GeometryFactory(PrecisionModel(), 4326))
@@ -436,6 +438,7 @@ actual class GeoUtil private actual constructor() {
          * @return the GeoJSON geometry.
          * @since 3.0.0
          */
+        @JvmStatic
         actual fun fromEWKB(raw: ByteArray?): SpGeometry? {
             if (raw == null) return null
             val reader = WKBReader(GeometryFactory(PrecisionModel(), 4326))
@@ -449,6 +452,7 @@ actual class GeoUtil private actual constructor() {
          * @return the GeoJSON geometry.
          * @since 3.0.0
          */
+        @JvmStatic
         actual fun fromWKB(raw: ByteArray?): SpGeometry? {
             if (raw == null) return null
             val reader = WKBReader(GeometryFactory(PrecisionModel(), 4326))
@@ -462,6 +466,7 @@ actual class GeoUtil private actual constructor() {
          * @return the encoded GeoJSON geometry.
          * @since 3.0.0
          */
+        @JvmStatic
         actual fun toTWKB(geometry: SpGeometry?): ByteArray? {
             if (geometry == null) return null
             val writer = TWKBWriter()
@@ -489,6 +494,7 @@ actual class GeoUtil private actual constructor() {
          * @return the encoded GeoJSON geometry.
          * @since 3.0.0
          */
+        @JvmStatic
         actual fun toEWKB(geometry: SpGeometry?): ByteArray? {
             if (geometry == null) return null
             val writer = WKBWriter(3, ByteOrderValues.BIG_ENDIAN, true)
@@ -501,6 +507,7 @@ actual class GeoUtil private actual constructor() {
          * @return the encoded GeoJSON geometry.
          * @since 3.0.0
          */
+        @JvmStatic
         actual fun toWKB(geometry: SpGeometry?): ByteArray? {
             if (geometry == null) return null
             val writer = WKBWriter(3, ByteOrderValues.BIG_ENDIAN, true)

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
@@ -31,7 +31,7 @@ import naksha.model.GeoEncoding.GeoEncoding_C.WKB_GZIP
 import naksha.model.NakshaError.NakshaErrorCompanion.ILLEGAL_ARGUMENT
 import naksha.model.NakshaError.NakshaErrorCompanion.ILLEGAL_ID
 import naksha.model.NakshaError.NakshaErrorCompanion.STORAGE_NOT_FOUND
-import naksha.model.NakshaVersion.Companion.LATEST
+import naksha.model.NakshaVersion.Companion.CURRENT
 import naksha.model.objects.NakshaFeature
 import naksha.model.objects.NakshaProperties
 import naksha.model.objects.NakshaStorage
@@ -936,7 +936,7 @@ class Naksha private constructor() {
                 var options = _adminOptions.get()
                 while (options == null) {
                     options = SessionOptions(
-                        appName = "lib-psql/$LATEST",
+                        appName = "lib-psql/$CURRENT",
                         appId = NakshaContext.appId(),
                         author = NakshaContext.author(),
                         parallel = false,

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/NakshaContext.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/NakshaContext.kt
@@ -406,7 +406,7 @@ open class NakshaContext protected constructor() {
          * @since 3.0.0
          */
         @JvmField
-        val defaultAppName = AtomicRef("NakshaClient/${NakshaVersion.LATEST}")
+        val defaultAppName = AtomicRef("NakshaClient/${NakshaVersion.CURRENT}")
 
         /**
          * The default application identifier to use, defaults to `null`.

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/NakshaVersion.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/NakshaVersion.kt
@@ -121,10 +121,13 @@ class NakshaVersion(
 
         const val v3_0_0_beta_7 = "3.0.0-beta.7"
 
+        const val v3_0_0_beta_8 = "3.0.0-beta.8"
+
         /**
-         * The latest version as string to constant usage cases.
+         * The current version as string to constant usage cases.
+         * @since 3.0
          */
-        const val LATEST = v3_0_0_beta_7
+        const val CURRENT = v3_0_0_beta_8
 
         /**
          * The current version of the Naksha library.
@@ -132,7 +135,7 @@ class NakshaVersion(
          */
         @JvmField
         @JsStatic
-        val current = of(LATEST)
+        val current = of(CURRENT)
 
         @JvmStatic
         @JsStatic

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgAdminMap.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgAdminMap.kt
@@ -412,6 +412,10 @@ SELECT basics.*, procs.* FROM basics, procs;
                     )
                 }
             }
+            // Note: We know, that we only get a new transaction number before we start a transaction.
+            //       Doing a commit here is necessary to avoid that we get a lock to the txn sequence!
+            //       Even while sequences are normally not locked, it can happen under circumstances.
+            conn.commit()
             return PgTxn(txn, txts, version)
         }
     }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgSession.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgSession.kt
@@ -205,11 +205,13 @@ open class PgSession(
      */
     override fun useTransaction(): NakshaTx = useTx().transaction
 
+    private var executionCount: Int = 0
+
     override fun execute(request: Request): Response {
         try {
             when (request) {
                 is WriteRequest -> {
-                    val writer = PgWriter(this)
+                    val writer = PgWriter(this, executionCount++ != 0)
                     return writer.execute(request.writes)
                 }
 
@@ -252,6 +254,7 @@ open class PgSession(
         val conn = pgConnection
         assertOpen()
         assertMutable()
+        executionCount = 0
         if (conn != null) {
             val tx = tx
             if (tx != null) {
@@ -259,7 +262,8 @@ open class PgSession(
                     val transaction = tx.transaction
                     val writeTx = Write().createFeature(Naksha.ADMIN_MAP, TRANSACTIONS_COL, transaction)
                     val writeRequest = WriteRequest().add(writeTx)
-                    val writer = PgWriter(this)
+                    // TODO: Should we use a savepoint here?
+                    val writer = PgWriter(this, false)
                     writer.execute(writeRequest.writes)
                 } catch (t: Throwable) {
                     throw generalException("Failed to save transaction", cause = t)
@@ -277,6 +281,7 @@ open class PgSession(
     }
 
     override fun rollback() {
+        executionCount = 0
         val conn = pgConnection
         if (conn != null) {
             try {

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
@@ -18,7 +18,19 @@ import kotlin.js.JsExport
  * @see [PgWrite]
  */
 @JsExport
-open class PgWriter internal constructor(val session: PgSession) {
+open class PgWriter internal constructor(
+    /**
+     * The session to which the writer is bound.
+     * @since 3.0
+     */
+    val session: PgSession,
+
+    /**
+     * If the writer should use save-point's.
+     * @since 3.0
+     */
+    val useSavepoint: Boolean
+) {
     /**
      * The storage to operate on.
      * @since 3.0
@@ -74,14 +86,14 @@ open class PgWriter internal constructor(val session: PgSession) {
         // Note: We must not close the connection, therefore no `session.useConnection().use {}`!
         val savepointId = PlatformUtil.randomString()
         val conn = session.useConnection()
-        conn.execute("SAVEPOINT \"$savepointId\"").close()
+        if (useSavepoint) conn.execute("SAVEPOINT \"$savepointId\"").close()
         try {
             prepareWrite(targetWrites)
             executeWrite(targetWrites)
             // If everything worked out as expected, we can drop the savepoint.
-            conn.execute("RELEASE SAVEPOINT \"$savepointId\"").close()
+            if (useSavepoint) conn.execute("RELEASE SAVEPOINT \"$savepointId\"").close()
         } catch (t: Throwable) {
-            conn.execute("ROLLBACK TO SAVEPOINT \"$savepointId\"").close()
+            if (useSavepoint) conn.execute("ROLLBACK TO SAVEPOINT \"$savepointId\"").close()
             throw PgExceptionMapper.map(t)
         }
 


### PR DESCRIPTION
Add fixes that avoid save-point's, when not needed, which will improve storage-api use case of bulk loading, because they cause LWLock's in the database. Same applies for the txn-sequence, which can, under circumstances, cause LWLocks on it.