### PR TITLE
v3 CASL 1278 race fix

### DIFF
--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
@@ -839,6 +839,18 @@ class Naksha private constructor() {
         fun useStorage(config: NakshaStorage): IStorage = _useStorage(config, null)
 
         private fun _useStorage(config: NakshaStorage, forceCreateOrUpgrade: Boolean?): IStorage {
+            val s = storagesByNumber[config.number]
+            val s2 = storagesById[config.id]
+            if (s !== s2) {
+                throw NakshaException(
+                    ILLEGAL_ARGUMENT,
+                    "The storage-id (${config.id}) and -number (${config.number}) belong to different storages")
+            }
+            if (s != null && s.config == config) {
+                // Only invoke initStorage, when we are forced to do it!
+                if (forceCreateOrUpgrade == true) s.invokeInitStorage(config, create = true, upgrade = true)
+                return s
+            }
             lock.acquire().use {
                 var storage = storagesByNumber[config.number]
                 val storage2 = storagesById[config.id]
@@ -848,10 +860,7 @@ class Naksha private constructor() {
                         "The storage-id (${config.id}) and -number (${config.number}) belong to different storages")
                 }
                 if (storage != null) {
-                    if (storage.config == config) {
-                        if (forceCreateOrUpgrade == true) storage.invokeInitStorage(config, create = true, upgrade = true)
-                        return storage
-                    }
+                    if (storage.config == config) return storage
                     storage.invokeShutdownStorage(false)
                 }
                 val klass = Platform.klassForName<AbstractStorage<*>>(config.className)

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
@@ -839,18 +839,6 @@ class Naksha private constructor() {
         fun useStorage(config: NakshaStorage): IStorage = _useStorage(config, null)
 
         private fun _useStorage(config: NakshaStorage, forceCreateOrUpgrade: Boolean?): IStorage {
-            val s = storagesByNumber[config.number]
-            val s2 = storagesById[config.id]
-            if (s !== s2) {
-                throw NakshaException(
-                    ILLEGAL_ARGUMENT,
-                    "The storage-id (${config.id}) and -number (${config.number}) belong to different storages")
-            }
-            if (s != null && s.config == config) {
-                // Only invoke initStorage, when we are forced to do it!
-                if (forceCreateOrUpgrade == true) s.invokeInitStorage(config, create = true, upgrade = true)
-                return s
-            }
             lock.acquire().use {
                 var storage = storagesByNumber[config.number]
                 val storage2 = storagesById[config.id]
@@ -860,7 +848,10 @@ class Naksha private constructor() {
                         "The storage-id (${config.id}) and -number (${config.number}) belong to different storages")
                 }
                 if (storage != null) {
-                    if (storage.config == config) return storage
+                    if (storage.config == config) {
+                        if (forceCreateOrUpgrade == true) storage.invokeInitStorage(config, create = true, upgrade = true)
+                        return storage
+                    }
                     storage.invokeShutdownStorage(false)
                 }
                 val klass = Platform.klassForName<AbstractStorage<*>>(config.className)

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
@@ -839,17 +839,24 @@ class Naksha private constructor() {
         fun useStorage(config: NakshaStorage): IStorage = _useStorage(config, null)
 
         private fun _useStorage(config: NakshaStorage, forceCreateOrUpgrade: Boolean?): IStorage {
-            val s = storagesByNumber[config.number]
-            val s2 = storagesById[config.id]
+            var s = storagesByNumber[config.number]
+            var s2 = storagesById[config.id]
             if (s !== s2) {
-                throw NakshaException(
-                    ILLEGAL_ARGUMENT,
-                    "The storage-id (${config.id}) and -number (${config.number}) belong to different storages")
+                lock.acquire().use {
+                    s = storagesByNumber[config.number]
+                    s2 = storagesById[config.id]
+                    if (s !== s2) {
+                        throw NakshaException(
+                            ILLEGAL_ARGUMENT,
+                            "The storage-id (${config.id}) and -number (${config.number}) belong to different storages")
+                    }
+                }
             }
-            if (s != null && s.config == config) {
+            val localS = s
+            if (localS != null && localS.config == config) {
                 // Only invoke initStorage, when we are forced to do it!
-                if (forceCreateOrUpgrade == true) s.invokeInitStorage(config, create = true, upgrade = true)
-                return s
+                if (forceCreateOrUpgrade == true) localS.invokeInitStorage(config, create = true, upgrade = true)
+                return localS
             }
             lock.acquire().use {
                 var storage = storagesByNumber[config.number]


### PR DESCRIPTION
# Jmeter local setup

## Run containers

### Admin

```
 docker run -d \
--env PGPASSWORD="password" \
--name naksha_admin \
-p 5433:5432 \
ghcr.io/naksha-oss/naksha-postgres:v16.2-r5
```

### Client

```
docker run -d \
--name naksha_client \
-p 5432:5432 \
hcr.data.here.com/naksha/postgres:populated-40k-by-naksha-cli-v1
```

## Run app

export NAKSHA_CONFIG_PATH=/Users/bczyz/Documents/perf-tests/config
export DB_URL="jdbc:postgresql://localhost:5433/postgres?user=postgres&password=password&schema=naksha&app=naksha&id=naksha_admin_db"
java -Xmx4096m -jar naksha.jar perf-config "$DB_URL"

With debug

java "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005" -Xmx4096m -jar naksha.jar perf-config "$DB_URL"

## Run jmeter perf test

Repo: https://main.gitlab.in.here.com/wall-e/common/cloud-architecture-2/naksha/tools/perf-tests

```
jmeter -n \
-t "jmeter/naksha_local_load.jmx" \
-JTILES_FILE="jmeter/tile_l15_under_1220013220.csv" \
-JPSQL_HOST="localhost" \
-l "./perf_test_results.jtl" \
-Jthreads=150 \
-JrampUp=300 \
-JloopCount=70 \
-Jtimeout=20000
``` 

## Generate html report

jmeter -g perf_test_results.jtl -o report-folder

## How to open jmeter in gui mode

jmeter -t jmeter/naksha_local_load.jmx 