### PR TITLE
Add user-defined members and indices to NakshaCollection

### DIFF
--- a/.claude/skills/naksha-proxy/SKILL.md
+++ b/.claude/skills/naksha-proxy/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: naksha-proxy
+description: Generate a Naksha proxy (ObjectProxy / ListProxy / MapProxy) or a JsEnum class that follows the conventions used throughout `here-naksha-lib-*`. Use when the user asks to create a new proxy, model class, request type, or enumeration that wraps `PlatformObject` / `PlatformList` data, or asks to add typed accessors over an existing one.
+---
+
+# Naksha proxy / JsEnum skill
+
+This skill encodes the conventions for writing typed wrappers over `PlatformObject` / `PlatformList` in the Naksha codebase, plus the conventions for typed enumerations.
+
+## Core concepts
+
+- The JSON parser returns raw `PlatformObject` (map-like, exposed in lib-base as `AnyObject` which extends `MapProxy<String, Any>`) and `PlatformList` (list-like, exposed as `ListProxy<T>`).
+- A **proxy** is a typed view over one of those. The runtime data is the raw platform value; the proxy is a thin facade that exposes typed getters and setters via delegated properties. Apply a proxy at runtime via `anyObject.proxy(MyProxy::class)`.
+- Proxies are **cached** by the underlying map: `obj.proxy(Foo::class) === obj.proxy(Foo::class)`. They are bound to the same map once and never unlinked.
+- Proxies are **not thread-safe**; only one thread accesses a given instance at a time.
+- An **enumeration** extends `naksha.base.JsEnum`. Values are registered statically through `def(...)` or `defIgnoreCase(...)`. They serialize as plain strings/ints in JSON.
+- Both flavors are `@JsExport`-ed because the same code runs on JVM and JS.
+- For every property, the canonical surface a caller can rely on is four methods: `has<Name>()`, `get<Name>()`, `set<Name>(value)`, `remove<Name>()`. Kotlin's `var name by DELEGATE` compiles to `getName`/`setName` automatically; `hasName`/`removeName` must be written explicitly. Generate all four for every property unless the user explicitly asks for a slimmer surface.
+
+## When NOT to use
+
+- Plain Kotlin data classes that never round-trip through JSON parsing. Use `data class` instead.
+- Static configuration that doesn't need to be exported to JS — use `companion object` / `enum class`.
+
+## Workflow
+
+Before generating anything, do these in order:
+
+1. **Confirm the kind**. Ask which is wanted if unclear:
+   - **Object proxy** — typed view over a JSON object (most common)
+   - **List proxy** — typed view over a JSON array of homogeneous elements
+   - **Map proxy** — typed view over a JSON map with non-string keys (rare)
+   - **JsEnum** — closed set of named string/int values
+2. **Confirm the property list** (for proxies): name, kotlin type, nullable, default value, optional JSON key override.
+3. **Locate the target module/package**. Naksha's convention is one file per public type, package mirrors directory, package name is lowercase `naksha.<module>.<sub>`. Use `grep -R "<NeighborClass>" here-naksha-lib-*/src/commonMain/kotlin` to find the right neighbor.
+4. **Generate the file** using the matching template below.
+5. **Validate** with the checklist at the end.
+
+## Object proxy template
+
+A typed view over an `AnyObject` (= `MapProxy<String, Any>`). Use this 90% of the time.
+
+```kotlin
+@file:Suppress("OPT_IN_USAGE")
+
+package <package>
+
+import naksha.base.*
+import kotlin.js.JsExport
+import kotlin.jvm.JvmField
+
+/**
+ * One short sentence describing what this models.
+ * @since 3.0
+ */
+@JsExport
+open class <ClassName> : AnyObject() {
+
+    /**
+     * Doc for [propName]. Mention units, range, defaults, and {Create-Only} if relevant.
+     * @since 3.0
+     */
+    var <propName>: <Type> by <DELEGATE>
+
+    /** True iff the underlying map has an entry for [propName]. */
+    fun has<PropName>(): Boolean = hasRaw("<jsonKey>")
+
+    /** Remove [propName] from the underlying map; returns this for chaining. */
+    fun remove<PropName>(): <ClassName> {
+        removeRaw("<jsonKey>")
+        return this
+    }
+
+    /** Fluent setter for [propName]; returns this for chaining. */
+    fun with<PropName>(value: <Type>): <ClassName> {
+        <propName> = value
+        return this
+    }
+
+    // ...repeat for each property
+
+    companion object <ClassName>_C {
+        // One private delegate per property; placing them in companion lets the Kotlin
+        // compiler inline the getter/setter calls.
+        private val <DELEGATE> = NotNullProperty<<ClassName>, <Type>>(<Type>::class) { _, _ -> <default> }
+        // For nullable string property with no default:
+        // private val STRING_NULL = NullableProperty<<ClassName>, String>(String::class)
+        // For nullable property that should be REMOVED from the underlying map when set to null:
+        // private val PROP_NULL = NullableProperty<<ClassName>, Foo>(Foo::class, autoRemove = true)
+        // For nullable property that should be auto-created on first read:
+        // private val PROP_NULL = NullableProperty<<ClassName>, NakshaList>(NakshaList::class, autoCreate = true)
+        // For an enum-typed property:
+        // private val MODE = NotNullEnum<<ClassName>, StoreMode>(StoreMode::class) { _, _ -> StoreMode.ON }
+        // private val MODE_NULL = NullableEnum<<ClassName>, StoreMode>(StoreMode::class)
+    }
+}
+```
+
+`<jsonKey>` is the same string the underlying map uses. It defaults to the Kotlin property name; only differs when the delegate is constructed with `name = "<jsonKey>"` (see *Renaming the JSON key* below). `hasRaw` / `removeRaw` bypass the delegate, so they need the wire key directly.
+
+### Delegate choice cheat sheet
+
+| Property declared as | Delegate to use |
+|---|---|
+| `var x: String by D` | `NotNullProperty<Self, String>(String::class) { _, _ -> "" }` |
+| `var x: String? by D` | `NullableProperty<Self, String>(String::class)` |
+| `var x: Int by D` | `NotNullProperty<Self, Int>(Int::class) { _, _ -> 0 }` |
+| `var x: Int64 by D` | `NotNullProperty<Self, Int64>(Int64::class) { _, _ -> Int64(0) }` |
+| `var x: Boolean by D` | `NotNullProperty<Self, Boolean>(Boolean::class) { _, _ -> false }` |
+| `var x: MyProxy by D` (auto-created on first read) | `NotNullProperty<Self, MyProxy>(MyProxy::class)` — no `init` lambda; `MyProxy`'s default constructor is invoked the first time the property is read while absent. This is the only way to get auto-create on a non-null proxy-typed property. |
+| `var x: MyProxy? by D` | `NullableProperty<Self, MyProxy>(MyProxy::class)` |
+| `var x: MyEnum by D` | `NotNullEnum<Self, MyEnum>(MyEnum::class) { _, _ -> MyEnum.DEFAULT }` |
+| `var x: MyEnum? by D` | `NullableEnum<Self, MyEnum>(MyEnum::class)` |
+
+### "Required, no default"
+
+`NotNullProperty` always returns a value, so it always needs an initializer. When the user says a property is "required, no default", they usually mean one of three things — pick deliberately:
+
+1. **Sentinel default + downstream validation.** Use `{ _, _ -> "" }` (or `0`, `Int64(0)`, `false`, ...) and rely on a `validate()` method or caller-side check to reject the sentinel before serializing. This is the codebase's prevailing pattern. Use it unless told otherwise.
+2. **Treat as nullable internally.** Declare `var x: String? by NullableProperty(...)` and let callers handle absence. Lose type strength but get true "missing".
+3. **Throw from the init lambda.** `{ _, name -> throw illegalArg("required property '$name' missing") }`. Use only when reading a missing required property is an actual programmer error rather than user input.
+
+### Renaming the JSON key
+
+The delegate uses the Kotlin property name as the map key by default. **Only pass `name = "<wireKey>"` when the JSON key differs from the Kotlin property name.** Passing `name=` redundantly is noise:
+
+```kotlin
+// Correct — Kotlin name `mapId`, wire key "map_id" (snake_case)
+private val MAP_ID = NullableProperty<NakshaCollection, String>(String::class, name = "map_id")
+
+// Incorrect — Kotlin name `indexed`, wire key "indexed". The `name =` is redundant; omit it.
+private val INDEXED = NotNullProperty<Foo, Boolean>(Boolean::class, name = "indexed") { _, _ -> true }
+```
+
+If you do override the wire key, use the same string for both the `name =` argument *and* every `hasRaw("...")` / `removeRaw("...")` call — those bypass the delegate and need the raw map key.
+
+## List proxy template
+
+Typed view over a `PlatformList` of homogeneous elements.
+
+```kotlin
+@file:Suppress("OPT_IN_USAGE")
+
+package <package>
+
+import naksha.base.ListProxy
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
+/**
+ * A list of [ElementType].
+ * @since 3.0
+ */
+@JsExport
+open class <ClassName>() : ListProxy<<ElementType>>(<ElementType>::class) {
+
+    /** Initializer accepting a vararg of elements. */
+    @JsName("fromElements")
+    constructor(vararg elements: <ElementType>) : this() {
+        addAll(elements.toList())
+    }
+}
+```
+
+The `ListProxy` base already provides `size`, `add`, `addAll`, `set`, `removeAt`, `iterator`, etc.
+
+## Map proxy template
+
+Only when the JSON key is not a `String` (rare). Use:
+
+```kotlin
+@JsExport
+open class <ClassName> : MapProxy<<KeyType>, <ValueType>>(<KeyType>::class, <ValueType>::class)
+```
+
+For `Map<String, Any>` use `AnyObject` (defined as exactly that) and treat it as an object proxy.
+
+## JsEnum template
+
+Closed set of named values that serialize as strings (most common) or ints. Use `defIgnoreCase` if the wire form should be matched without case sensitivity.
+
+```kotlin
+@file:Suppress("OPT_IN_USAGE")
+
+package <package>
+
+import naksha.base.JsEnum
+import kotlin.js.JsExport
+import kotlin.jvm.JvmField
+import kotlin.reflect.KClass
+
+/**
+ * One short sentence describing the enumeration's purpose.
+ * - [ON] description of ON
+ * - [OFF] description of OFF
+ * @since 3.0
+ */
+@JsExport
+class <ClassName> : JsEnum() {
+
+    @Suppress("NON_EXPORTABLE_TYPE")
+    override fun namespace(): KClass<out JsEnum> = <ClassName>::class
+
+    override fun initClass() {}
+
+    companion object <ClassName>_C {
+        /** Doc for [ON]. */
+        @JvmField
+        val ON = defIgnoreCase(<ClassName>::class, "on")
+
+        /** Doc for [OFF]. */
+        @JvmField
+        val OFF = defIgnoreCase(<ClassName>::class, "off")
+    }
+}
+```
+
+### `def` vs `defIgnoreCase`
+
+- `def(Klass, "Value")` — case-sensitive. Use when the wire form is fixed (e.g. uppercase constants, ints).
+- `defIgnoreCase(Klass, "value")` — case-insensitive on input but emits exactly what's passed on output. Default choice for human-typed config values.
+
+### Integer-valued enums
+
+Use `def(Klass, intValue)` instead of a string. The companion still uses `@JvmField val FOO = ...`.
+
+### Subclass per value (legacy)
+
+A few legacy enums use one Kotlin subclass per constant (see `here-naksha-lib-base/src/commonMain/kotlin/naksha/base/JsEnum.kt` doc block). Do **not** use this pattern for new code — single-class with `companion object` constants is the current convention.
+
+## File placement
+
+- Package follows the directory: `here-naksha-lib-<module>/src/commonMain/kotlin/naksha/<module>/.../<ClassName>.kt`
+- One public class per file.
+- Filename matches the class name.
+- New types that downstream code already references go next to their nearest neighbor in the existing directory tree.
+
+## Conventions checklist (run before declaring done)
+
+1. **Header**: `@file:Suppress("OPT_IN_USAGE")` is present. Add `"LeakingThis"` if `init {}` writes to `this` properties.
+2. **Class is `@JsExport`** and `open class` (proxies must allow subclassing for `proxy()` to work).
+3. **Companion** is named `<ClassName>_C` (matches the rest of the codebase).
+4. **Companion delegates are `private val`** — never `internal` or public.
+5. **One delegate per property**. Sharing a single `STRING_NULL` delegate across multiple properties is fine *only* if their JSON key matches their Kotlin name and they share an initializer.
+6. **All public properties have KDoc** ending in `@since 3.0`. Use exactly `3.0` (two components) — that's what `NakshaCollection.kt` / `NakshaFeature.kt` and the rest of the model module use. A few older files use `3.0.0`; ignore them.
+7. **No constructor logic that reads properties** — proxies are usually instantiated by `<obj>.proxy(MyProxy::class)`, and the constructor runs against an empty `AnyObject`. Use delegate `init = { _, _ -> ... }` for defaults instead.
+8. **`with<Prop>` returns `<ClassName>`**, not the base class. If the proxy extends another proxy that already has a `with<Prop>`, override with `as <ClassName>` cast (see `NakshaCollection.withId`).
+9. **Enums use `@JvmField`** on companion constants. Add `@JsStatic` only if JS callers need direct access (most don't — they go through `JsEnum.get`).
+10. **Validate the package compiles**: `nix develop --command bash -c 'cd naksha && gradle :here-naksha-lib-<module>:compileKotlinJvm 2>&1 | tail -30'` (the build script ignores `kotlin.compiler.execution.strategy` warnings).
+
+## Examples in the codebase
+
+Use these as exact references for the conventions, not as code to copy:
+
+- Object proxy: `here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaCollection.kt`
+- Object proxy with enum + auto-create: `here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaFeature.kt`
+- List proxy: `here-naksha-lib-base/src/commonMain/kotlin/naksha/base/StringList.kt`
+- JsEnum (small): `here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/StoreMode.kt`
+- JsEnum (with intValue and aliases): `here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Action.kt`
+- Delegate definitions: `here-naksha-lib-base/src/commonMain/kotlin/naksha/base/NotNullProperty.kt`, `NullableProperty.kt`, `NotNullEnum.kt`, `NullableEnum.kt`
+
+## Common pitfalls
+
+- **Forgetting `@JsExport`** — JS callers can't see the class, but JVM still works, so this slips through unless you actually run the JS target.
+- **Putting initializer code in the constructor body** — for proxies, prefer the `init = { _, _ -> default }` lambda on the delegate. The constructor often runs in contexts (deserialization, `proxy()` cast) where reading other properties would yield defaults.
+- **Sharing one delegate across properties with different defaults** — if the values diverge later, the shared delegate produces wrong defaults silently. Keep one delegate per property unless they truly are identical.
+- **Using `kotlin.enum`** — the project uses `JsEnum`. A Kotlin `enum class` does not survive JSON round-tripping the way `JsEnum` does.
+- **Adding `has<Name>()` / `remove<Name>()` for every property** — only add them when the property is genuinely optional in the wire format. Required properties don't need them; the delegate's default handles presence.
+- **Renaming a property without updating the JSON key** — if the property name was the JSON key, renaming silently breaks serialization. Either keep the old name as `name=` on the delegate, or include both in a deprecation cycle.

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomIndex.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomIndex.kt
@@ -1,0 +1,154 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.AnyObject
+import naksha.base.NotNullEnum
+import naksha.base.NotNullProperty
+import naksha.base.NullableProperty
+import naksha.base.StringList
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
+/**
+ * A user-defined index on a [NakshaCollection].
+ *
+ * The [on] columns may reference built-in columns (`id`, `geo`, `tags`, ...) or [CustomMember.name]s declared on the same collection. The [type] decides the storage method:
+ * - [CustomIndexType.BTREE]: standard B-tree, supports equality and range queries on scalar and `text` columns.
+ * - [CustomIndexType.GEO]: GIST + SPGIST pair on a 2D-encoded geometry column. `on` must contain exactly one geometry column.
+ * - [CustomIndexType.JSON]: GIN inverted index over a `jsonb` (or built-in `feature` / `tags`) column. `on` must contain exactly one column.
+ * @since 3.0
+ */
+@JsExport
+open class CustomIndex() : AnyObject() {
+
+    /**
+     * Construct an index.
+     * @param name the index name (must be unique within the collection).
+     * @param type the index type.
+     * @param on the columns to index.
+     * @since 3.0
+     */
+    @JsName("of")
+    constructor(name: String, type: CustomIndexType, vararg on: String) : this() {
+        this.name = name
+        this.type = type
+        val cols = StringList()
+        cols.setCapacity(on.size)
+        for (c in on) cols.add(c)
+        this.on = cols
+    }
+
+    /**
+     * The index name. Must be unique within the collection.
+     * @since 3.0
+     */
+    var name: String by NAME
+
+    /** True iff the underlying map has an entry for [name]. */
+    fun hasName(): Boolean = hasRaw("name")
+
+    /** Remove [name] from the underlying map; returns this for chaining. */
+    fun removeName(): CustomIndex {
+        removeRaw("name")
+        return this
+    }
+
+    /** Fluent setter for [name]; returns this for chaining. */
+    fun withName(value: String): CustomIndex {
+        name = value
+        return this
+    }
+
+    /**
+     * The index type.
+     * @since 3.0
+     */
+    var type: CustomIndexType by TYPE
+
+    /** True iff the underlying map has an entry for [type]. */
+    fun hasType(): Boolean = hasRaw("type")
+
+    /** Remove [type] from the underlying map; returns this for chaining. */
+    fun removeType(): CustomIndex {
+        removeRaw("type")
+        return this
+    }
+
+    /** Fluent setter for [type]; returns this for chaining. */
+    fun withType(value: CustomIndexType): CustomIndex {
+        type = value
+        return this
+    }
+
+    /**
+     * The columns to index. May reference built-in columns or [CustomMember.name]s on the same collection.
+     * @since 3.0
+     */
+    var on: StringList by ON
+
+    /** True iff the underlying map has an entry for [on]. */
+    fun hasOn(): Boolean = hasRaw("on")
+
+    /** Remove [on] from the underlying map; returns this for chaining. */
+    fun removeOn(): CustomIndex {
+        removeRaw("on")
+        return this
+    }
+
+    /** Fluent setter for [on]; returns this for chaining. */
+    fun withOn(value: StringList): CustomIndex {
+        on = value
+        return this
+    }
+
+    /**
+     * Optional columns to include in the index leaf pages (`INCLUDE (...)`). Only used by [CustomIndexType.BTREE].
+     * @since 3.0
+     */
+    var include: StringList? by INCLUDE
+
+    /** True iff the underlying map has an entry for [include]. */
+    fun hasInclude(): Boolean = hasRaw("include")
+
+    /** Remove [include] from the underlying map; returns this for chaining. */
+    fun removeInclude(): CustomIndex {
+        removeRaw("include")
+        return this
+    }
+
+    /** Fluent setter for [include]; returns this for chaining. */
+    fun withInclude(value: StringList?): CustomIndex {
+        include = value
+        return this
+    }
+
+    /**
+     * Whether the index enforces uniqueness across the [on] columns. Defaults to `false`.
+     * @since 3.0
+     */
+    var unique: Boolean by UNIQUE
+
+    /** True iff the underlying map has an entry for [unique]. */
+    fun hasUnique(): Boolean = hasRaw("unique")
+
+    /** Remove [unique] from the underlying map; returns this for chaining. */
+    fun removeUnique(): CustomIndex {
+        removeRaw("unique")
+        return this
+    }
+
+    /** Fluent setter for [unique]; returns this for chaining. */
+    fun withUnique(value: Boolean): CustomIndex {
+        unique = value
+        return this
+    }
+
+    companion object CustomIndex_C {
+        private val NAME = NotNullProperty<CustomIndex, String>(String::class) { _, _ -> "" }
+        private val TYPE = NotNullEnum<CustomIndex, CustomIndexType>(CustomIndexType::class) { _, _ -> CustomIndexType.BTREE }
+        private val ON = NotNullProperty<CustomIndex, StringList>(StringList::class)
+        private val INCLUDE = NullableProperty<CustomIndex, StringList>(StringList::class)
+        private val UNIQUE = NotNullProperty<CustomIndex, Boolean>(Boolean::class) { _, _ -> false }
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomIndexList.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomIndexList.kt
@@ -1,0 +1,31 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.ListProxy
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlin.jvm.JvmStatic
+
+/**
+ * An ordered list of user-defined indexes on a [NakshaCollection].
+ * @since 3.0
+ */
+@JsExport
+open class CustomIndexList() : ListProxy<CustomIndex>(CustomIndex::class) {
+
+    /**
+     * Construct a list from a vararg of indexes.
+     * @since 3.0
+     */
+    @JsName("fromIndexes")
+    constructor(vararg indexes: CustomIndex) : this() {
+        addAll(indexes.toList())
+    }
+
+    companion object CustomIndexList_C {
+        @JvmStatic
+        fun of(vararg indexes: CustomIndex): CustomIndexList =
+            CustomIndexList().apply { addAll(indexes.toList()) }
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomIndexType.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomIndexType.kt
@@ -1,0 +1,48 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.JsEnum
+import kotlin.js.JsExport
+import kotlin.jvm.JvmField
+import kotlin.reflect.KClass
+
+/**
+ * The kind of index to create for a [CustomIndex].
+ *
+ * - [BTREE] — ordered index for equality and range queries on primitive columns (numbers, booleans, strings, byte-arrays).
+ * - [SPATIAL] — spatial index over a geometry column (e.g. the built-in `geo`).
+ * - [FLAT_MAP] — inverted index over a column of [CustomMemberType.FLAT_MAP] or [CustomMemberType.TAGS]; supports key/value containment lookups.
+ * @since 3.0
+ */
+@JsExport
+class CustomIndexType : JsEnum() {
+
+    @Suppress("NON_EXPORTABLE_TYPE")
+    override fun namespace(): KClass<out JsEnum> = CustomIndexType::class
+
+    override fun initClass() {}
+
+    companion object CustomIndexType_C {
+        /**
+         * Ordered index for equality and range queries on primitive columns.
+         * @since 3.0
+         */
+        @JvmField
+        val BTREE = defIgnoreCase(CustomIndexType::class, "btree")
+
+        /**
+         * Spatial index over a geometry column.
+         * @since 3.0
+         */
+        @JvmField
+        val SPATIAL = defIgnoreCase(CustomIndexType::class, "spatial")
+
+        /**
+         * Inverted index over a [CustomMemberType.FLAT_MAP] or [CustomMemberType.TAGS] column.
+         * @since 3.0
+         */
+        @JvmField
+        val FLAT_MAP = defIgnoreCase(CustomIndexType::class, "flat_map")
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomMember.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomMember.kt
@@ -1,0 +1,121 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.AnyObject
+import naksha.base.NotNullEnum
+import naksha.base.NotNullProperty
+import naksha.base.NullableProperty
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
+/**
+ * A user-defined SQL column materialized on a [NakshaCollection].
+ *
+ * At write time, the storage walks the feature using [map], extracts the value, coerces it to the [dataType], and stores it in a storage-specific column derived from [name]. The value also remains in the encoded feature blob.
+ *
+ * The [name] must be a valid Naksha identifier (see [naksha.model.Naksha.verifyId]). Storages typically reserve a separate namespace for user columns (e.g. `lib-psql` materializes a member named `foo` as the physical column `$foo`).
+ *
+ * If [map] is not set, the storage defaults to `["properties", <name>]` at write time.
+ * @since 3.0
+ */
+@JsExport
+open class CustomMember() : AnyObject() {
+
+    /**
+     * Construct a member with a name and the given data type.
+     * @param name the column name.
+     * @param dataType the SQL data type; defaults to [CustomMemberType.STRING].
+     * @param map the JSON path to read the value from; defaults to `["properties", name]` when null.
+     * @since 3.0
+     */
+    @JsName("of")
+    constructor(name: String, dataType: CustomMemberType = CustomMemberType.STRING, map: JsonPath? = null) : this() {
+        this.name = name
+        this.dataType = dataType
+        if (map != null) this.map = map
+    }
+
+    /**
+     * The column name. Must match `^[a-z][a-z0-9_]{0,62}$` and must not collide with a reserved built-in column name.
+     * @since 3.0
+     */
+    var name: String by NAME
+
+    /** True iff the underlying map has an entry for [name]. */
+    fun hasName(): Boolean = hasRaw("name")
+
+    /** Remove [name] from the underlying map; returns this for chaining. */
+    fun removeName(): CustomMember {
+        removeRaw("name")
+        return this
+    }
+
+    /** Fluent setter for [name]; returns this for chaining. */
+    fun withName(value: String): CustomMember {
+        name = value
+        return this
+    }
+
+    /**
+     * The Postgres data type used to materialize this member as a real SQL column.
+     * @since 3.0
+     */
+    var dataType: CustomMemberType by DATA_TYPE
+
+    /** True iff the underlying map has an entry for [dataType]. */
+    fun hasDataType(): Boolean = hasRaw("dataType")
+
+    /** Remove [dataType] from the underlying map; returns this for chaining. */
+    fun removeDataType(): CustomMember {
+        removeRaw("dataType")
+        return this
+    }
+
+    /** Fluent setter for [dataType]; returns this for chaining. */
+    fun withDataType(value: CustomMemberType): CustomMember {
+        dataType = value
+        return this
+    }
+
+    /**
+     * The JSON path to read the value from at write time. If `null`, the storage defaults to `["properties", name]`.
+     *
+     * Each segment must match `^[A-Za-z_][A-Za-z0-9_]*$`. There is no array indexing in v3.0.
+     * @since 3.0
+     */
+    var map: JsonPath? by MAP
+
+    /** True iff the underlying map has an entry for [map]. */
+    fun hasMap(): Boolean = hasRaw("map")
+
+    /** Remove [map] from the underlying map; returns this for chaining. */
+    fun removeMap(): CustomMember {
+        removeRaw("map")
+        return this
+    }
+
+    /** Fluent setter for [map]; returns this for chaining. */
+    fun withMap(value: JsonPath?): CustomMember {
+        map = value
+        return this
+    }
+
+    /**
+     * Returns the effective JSON path to read this member from a feature.
+     *
+     * If [map] is explicitly set, returns its contents; otherwise returns `["properties", name]`.
+     * @since 3.0
+     */
+    fun effectivePath(): List<String> {
+        val m = map
+        return if (m != null && m.isNotEmpty()) m.filterNotNull().toList()
+        else listOf("properties", name)
+    }
+
+    companion object CustomMember_C {
+        private val NAME = NotNullProperty<CustomMember, String>(String::class) { _, _ -> "" }
+        private val DATA_TYPE = NotNullEnum<CustomMember, CustomMemberType>(CustomMemberType::class) { _, _ -> CustomMemberType.STRING }
+        private val MAP = NullableProperty<CustomMember, JsonPath>(JsonPath::class)
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomMemberList.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomMemberList.kt
@@ -1,0 +1,37 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.ListProxy
+import kotlin.js.JsExport
+import kotlin.js.JsName
+import kotlin.jvm.JvmStatic
+
+/**
+ * An ordered list of user-defined SQL columns on a [NakshaCollection].
+ * @since 3.0
+ */
+@JsExport
+open class CustomMemberList() : ListProxy<CustomMember>(CustomMember::class) {
+
+    /**
+     * Construct a list from a vararg of members.
+     * @since 3.0
+     */
+    @JsName("fromMembers")
+    constructor(vararg members: CustomMember) : this() {
+        addAll(members.toList())
+    }
+
+    companion object CustomMemberList_C {
+        /**
+         * The maximum number of members allowed in a single collection.
+         * @since 3.0
+         */
+        const val MAX_MEMBERS = 64
+
+        @JvmStatic
+        fun of(vararg members: CustomMember): CustomMemberList =
+            CustomMemberList().apply { addAll(members.toList()) }
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomMemberType.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/CustomMemberType.kt
@@ -1,0 +1,110 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.JsEnum
+import kotlin.js.JsExport
+import kotlin.jvm.JvmField
+import kotlin.reflect.KClass
+
+/**
+ * The logical data type of a [CustomMember].
+ *
+ * - Primitives: [BOOLEAN], [INT8], [INT16], [INT32], [INT64], [FLOAT32], [FLOAT64], [STRING], [BYTE_ARRAY].
+ * - [FLAT_MAP]: a virtual type for a map whose values are all primitives and whose keys are all strings.
+ * - [TAGS]: a virtual type whose input is a string-array using the Naksha tag syntax (`key=value`, `key:=number`, ...), and whose materialized form is a [FLAT_MAP].
+ *
+ * Storages decide how to materialize these (e.g. `lib-psql` translates [FLAT_MAP] and [TAGS] to `jsonb`).
+ * @since 3.0
+ */
+@JsExport
+class CustomMemberType : JsEnum() {
+
+    @Suppress("NON_EXPORTABLE_TYPE")
+    override fun namespace(): KClass<out JsEnum> = CustomMemberType::class
+
+    override fun initClass() {}
+
+    companion object CustomMemberType_C {
+        /**
+         * Boolean.
+         * @since 3.0
+         */
+        @JvmField
+        val BOOLEAN = defIgnoreCase(CustomMemberType::class, "boolean")
+
+        /**
+         * 8-bit signed integer.
+         * @since 3.0
+         */
+        @JvmField
+        val INT8 = defIgnoreCase(CustomMemberType::class, "int8")
+
+        /**
+         * 16-bit signed integer.
+         * @since 3.0
+         */
+        @JvmField
+        val INT16 = defIgnoreCase(CustomMemberType::class, "int16")
+
+        /**
+         * 32-bit signed integer.
+         * @since 3.0
+         */
+        @JvmField
+        val INT32 = defIgnoreCase(CustomMemberType::class, "int32")
+
+        /**
+         * 64-bit signed integer.
+         * @since 3.0
+         */
+        @JvmField
+        val INT64 = defIgnoreCase(CustomMemberType::class, "int64")
+
+        /**
+         * 32-bit IEEE-754 floating point.
+         * @since 3.0
+         */
+        @JvmField
+        val FLOAT32 = defIgnoreCase(CustomMemberType::class, "float32")
+
+        /**
+         * 64-bit IEEE-754 floating point.
+         * @since 3.0
+         */
+        @JvmField
+        val FLOAT64 = defIgnoreCase(CustomMemberType::class, "float64")
+
+        /**
+         * Variable-length UTF-8 text.
+         * @since 3.0
+         */
+        @JvmField
+        val STRING = defIgnoreCase(CustomMemberType::class, "string")
+
+        /**
+         * Raw byte array.
+         * @since 3.0
+         */
+        @JvmField
+        val BYTE_ARRAY = defIgnoreCase(CustomMemberType::class, "byte_array")
+
+        /**
+         * A map whose values are all primitives and whose keys are all strings.
+         *
+         * Storages typically materialize this as a single document column (e.g. `jsonb` in PostgreSQL).
+         * @since 3.0
+         */
+        @JvmField
+        val FLAT_MAP = defIgnoreCase(CustomMemberType::class, "flat_map")
+
+        /**
+         * A string-array using Naksha tag syntax that is expanded into a [FLAT_MAP] at write time.
+         *
+         * Input is `["key=value", "name:=42"]`; materialized form is `{"key":"value", "name":42}`.
+         * @since 3.0
+         */
+        @JvmField
+        val TAGS = defIgnoreCase(CustomMemberType::class, "tags")
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/JsonPath.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/JsonPath.kt
@@ -1,0 +1,29 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.objects
+
+import naksha.base.ListProxy
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
+/**
+ * An ordered list of object keys used to walk a JSON document.
+ *
+ * For example, `JsonPath("properties", "age")` resolves the value at `feature.properties.age`.
+ *
+ * Each segment must match `^[A-Za-z_][A-Za-z0-9_]*$`. There is no array indexing in v3.0 — paths can only descend into object keys.
+ * @since 3.0
+ */
+@JsExport
+open class JsonPath() : ListProxy<String>(String::class) {
+
+    /**
+     * Construct a path from a vararg of segments.
+     * @param segments the path segments.
+     * @since 3.0
+     */
+    @JsName("fromSegments")
+    constructor(vararg segments: String) : this() {
+        addAll(segments.toList())
+    }
+}

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaCollection.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaCollection.kt
@@ -8,6 +8,8 @@ import naksha.geo.SpGeometry
 import naksha.geo.SpPoint
 import naksha.model.Flags
 import naksha.model.Naksha
+import naksha.model.NakshaError
+import naksha.model.NakshaException
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlin.js.JsStatic
@@ -252,93 +254,122 @@ open class NakshaCollection() : NakshaFeature() {
     }
 
     /**
-     * The index list with all indices to add to the collection; if set to `null`, default indices are created.
+     * The user-defined columns to materialize on this collection.
      *
-     * For `lib-psql` the following indices are available:
-     * - `id`: Index above the `id` property _(added by default into HEAD)_, includes `tn`, and `next_tn`.
-     * - `here_tile`: Index above `here_tile`, includes `id`, `tn`, and `next_tn`.
-     * - `app_id`: Index above `app_id`, includes `updated_at`, `id`, `tn`, and `next_tn`.
-     * - `author`: Index above `author`, includes `author_ts`, `id`, `tn`, and `tn_next`.
-     * - `tags`: Index above tags, does not allow index-only scans or pre-ordering.
-     * - `ref_point`: Index above reference point geometry, does not allow index-only scans or pre-ordering.
-     * - `gist_geo` or `spgist_geo`: Index above geometry, does not allow index-only scans or pre-ordering.
-     * - `ft`: Index above `ft`, includes `id`, `tn`, and `next_tn`.
-     * - `cv0`, `cv1`, `cv2`, and `cv3`: Index above `cvX`, includes `id`, `tn`, and `next_tn`, does not index `null` values.
-     * - `cs0`, `cs1`, `cs2`, and `cs3`: Index above `csX`, includes `id`, `tn`, and `next_tn`, does not index `null` values.
+     * Each [CustomMember] declares a name, a [CustomMemberType] (defaults to [CustomMemberType.STRING]), and an optional [JsonPath] to extract the value from the feature. At write time, the storage walks the feature using the path, coerces the value to the declared type, and stores it as a real column on the underlying table. The value also remains in the encoded feature blob.
      *
-     * To use a specific set of indices, create an own list of indices out of the above given values.
+     * Members are immutable in shape: changing a member's [CustomMember.dataType] after creation is not supported. To remove a member, the upsert must explicitly opt in to dropping the column (storage-specific `force` flag).
      *
-     * **It is not recommended, to add multiple geometry indices, this can become extreme costly.**
+     * The [name] of a member must be a valid Naksha identifier (see [Naksha.verifyId]); storages reserve a separate namespace for user columns to avoid collisions with built-ins.
+     *
      * @since 3.0
      */
-    var indices by INDICES
+    var members: CustomMemberList? by MEMBERS
 
     /**
-     * Adds all given indices.
+     * @see [members]
+     */
+    @JsName("withMemberList")
+    open fun withMembers(values: CustomMemberList): NakshaCollection {
+        val list = CustomMemberList()
+        list.setCapacity(values.size)
+        list.addAll(values.toList())
+        this.members = list
+        return this
+    }
+
+    /**
+     * @see [members]
+     */
+    open fun withMembers(vararg values: CustomMember): NakshaCollection {
+        val list = CustomMemberList()
+        list.setCapacity(values.size)
+        for (v in values) list.add(v)
+        this.members = list
+        return this
+    }
+
+    /**
+     * Adds the given [CustomMember] to [members].
      *
-     * ### Note
-     * This method does **not** add the given list, this method copies the elements from the given list into a new list.
-     * @param values the indices to add.
+     * Validates that the [CustomMember.name] is a valid Naksha identifier (see [Naksha.verifyId]) and does not already exist on this collection. Caps the list at [CustomMemberList.MAX_MEMBERS] entries.
+     * @param value the member to add.
      * @return this.
      * @since 3.0
+     */
+    open fun addMember(value: CustomMember): NakshaCollection {
+        Naksha.verifyId(value.name)
+        var list = this.members
+        if (list == null) {
+            list = CustomMemberList()
+            this.members = list
+        }
+        for (existing in list) {
+            if (existing != null && existing.name == value.name) {
+                throw NakshaException(NakshaError.ILLEGAL_ARGUMENT, "Duplicate member name: '${value.name}'")
+            }
+        }
+        if (list.size >= CustomMemberList.MAX_MEMBERS) {
+            throw NakshaException(NakshaError.ILLEGAL_ARGUMENT, "Cannot add more than ${CustomMemberList.MAX_MEMBERS} members to a collection")
+        }
+        list.add(value)
+        return this
+    }
+
+    /**
+     * The user-defined indices to maintain on this collection.
+     *
+     * Each [CustomIndex] declares a name, a [CustomIndexType] ([CustomIndexType.BTREE] / [CustomIndexType.SPATIAL] / [CustomIndexType.FLAT_MAP]), the column(s) to index, an optional include-list (for [CustomIndexType.BTREE]), and a `unique` flag.
+     *
+     * Indices are applied to every variant of the collection (HEAD, HISTORY, DELETED, META) by the storage.
+     * @since 3.0
+     */
+    var indices: CustomIndexList? by INDICES
+
+    /**
      * @see [indices]
      */
     @JsName("withIndexList")
-    open fun withIndices(values: StringList): NakshaCollection {
-        val indices = StringList()
-        indices.setCapacity(values.size)
-        indices.addAll(values)
-        this.indices = indices
+    open fun withIndices(values: CustomIndexList): NakshaCollection {
+        val list = CustomIndexList()
+        list.setCapacity(values.size)
+        list.addAll(values.toList())
+        this.indices = list
         return this
     }
 
     /**
-     * Adds all given indices.
-     * @param values the indices to add.
+     * @see [indices]
+     */
+    open fun withIndices(vararg values: CustomIndex): NakshaCollection {
+        val list = CustomIndexList()
+        list.setCapacity(values.size)
+        for (v in values) list.add(v)
+        this.indices = list
+        return this
+    }
+
+    /**
+     * Adds the given [CustomIndex] to [indices].
+     *
+     * Validates that the index [CustomIndex.name] is a valid Naksha identifier (see [Naksha.verifyId]) and is unique within this collection.
+     * @param value the index to add.
      * @return this.
      * @since 3.0
-     * @see [indices]
      */
-    open fun withIndices(vararg values: String): NakshaCollection {
-        val indices = StringList()
-        indices.setCapacity(values.size)
-        for (value in values) indices.append(value)
-        this.indices = indices
-        return this
-    }
-
-    /**
-     * Adds the given `index` into the list of [indices], when not being in already.
-     * @param value the index to add to [indices].
-     * @return this.
-     * @see [indices]
-     */
-    open fun addIndex(value: String): NakshaCollection {
-        var indices = this.indices
-        if (indices == null) {
-            indices = StringList()
-            this.indices = indices
+    open fun addCustomIndex(value: CustomIndex): NakshaCollection {
+        Naksha.verifyId(value.name)
+        var list = this.indices
+        if (list == null) {
+            list = CustomIndexList()
+            this.indices = list
         }
-        if (!indices.contains(value)) indices.add(value)
-        return this
-    }
-
-    /**
-     * Adds the given `indices` into the list of [indices], when not being in already.
-     * @param values the indices to add to [indices].
-     * @return this.
-     * @see [indices]
-     */
-    open fun addIndices(vararg values: String): NakshaCollection {
-        @Suppress("SENSELESS_COMPARISON")
-        if (values != null && values.isNotEmpty()) {
-            var indices = this.indices
-            if (indices == null) {
-                indices = StringList()
-                this.indices = indices
+        for (existing in list) {
+            if (existing != null && existing.name == value.name) {
+                throw NakshaException(NakshaError.ILLEGAL_ARGUMENT, "Duplicate index name: '${value.name}'")
             }
-            for (value in values) if (!indices.contains(value)) indices.add(value)
         }
+        list.add(value)
         return this
     }
 
@@ -508,7 +539,8 @@ open class NakshaCollection() : NakshaFeature() {
         private val MAP_ID = NullableProperty<NakshaCollection, String>(String::class)
         private val STRING_NULL = NullableProperty<NakshaCollection, String>(String::class)
         private val DEFAULT_FEATURE_TYPE = NotNullProperty<NakshaCollection, String>(String::class) { _, _ -> TYPE }
-        private val INDICES = NullableProperty<NakshaCollection, StringList>(StringList::class)
+        private val MEMBERS = NullableProperty<NakshaCollection, CustomMemberList>(CustomMemberList::class)
+        private val INDICES = NullableProperty<NakshaCollection, CustomIndexList>(CustomIndexList::class)
         private val MAX_AGE = NotNullProperty<NakshaCollection, Int64>(Int64::class) { _, _ -> Int64(-1) }
         private val QUAD_PARTITION_SIZE = NotNullProperty<NakshaCollection, Int>(Int::class) { _, _ -> 10_485_760 }
         private val _ESTIMATED_FEATURE_COUNT = NotNullProperty<NakshaCollection, Int64>(Int64::class) { _, _ -> UNKNOWN }

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/Write.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/Write.kt
@@ -449,6 +449,24 @@ open class Write : AnyObject() {
     }
 
     /**
+     * If `true`, destructive collection-schema changes (currently: dropping a [naksha.model.objects.CustomMember]) are allowed during UPSERT/UPDATE.
+     *
+     * Without `force`, removing a [CustomMember][naksha.model.objects.CustomMember] from [NakshaCollection.members][naksha.model.objects.NakshaCollection.members] throws [NakshaError.ILLEGAL_ARGUMENT].
+     *
+     * Default `false`.
+     * @since 3.0
+     */
+    var force by BOOLEAN_FALSE
+
+    /**
+     * @see [force]
+     */
+    fun withForce(value: Boolean): Write {
+        force = value
+        return this
+    }
+
+    /**
      * Create a new dictionary.
      * @param dict the dictionary to create.
      * @return this.

--- a/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/CustomMemberTest.kt
+++ b/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/CustomMemberTest.kt
@@ -1,0 +1,104 @@
+package naksha.model
+
+import naksha.model.objects.CustomIndex
+import naksha.model.objects.CustomIndexType
+import naksha.model.objects.CustomMember
+import naksha.model.objects.CustomMemberList
+import naksha.model.objects.CustomMemberType
+import naksha.model.objects.JsonPath
+import naksha.model.objects.NakshaCollection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class CustomMemberTest {
+
+    @Test
+    fun defaultDataTypeIsString() {
+        val m = CustomMember("age")
+        assertEquals("age", m.name)
+        assertEquals(CustomMemberType.STRING, m.dataType)
+    }
+
+    @Test
+    fun effectivePathDefaultsToPropertiesName() {
+        val m = CustomMember("age", CustomMemberType.INT32)
+        assertEquals(listOf("properties", "age"), m.effectivePath())
+    }
+
+    @Test
+    fun effectivePathUsesExplicitMap() {
+        val m = CustomMember("price", CustomMemberType.FLOAT64, JsonPath("properties", "sale", "price"))
+        assertEquals(listOf("properties", "sale", "price"), m.effectivePath())
+    }
+
+    @Test
+    fun addMemberRejectsInvalidName() {
+        val c = NakshaCollection("my_coll")
+        assertFailsWith<NakshaException> { c.addMember(CustomMember("BadName")) }
+        assertFailsWith<NakshaException> { c.addMember(CustomMember("123start")) }
+        assertFailsWith<NakshaException> { c.addMember(CustomMember("with space")) }
+    }
+
+    @Test
+    fun addMemberRejectsDuplicates() {
+        val c = NakshaCollection("my_coll")
+        c.addMember(CustomMember("age", CustomMemberType.INT32))
+        assertFailsWith<NakshaException> { c.addMember(CustomMember("age", CustomMemberType.INT64)) }
+    }
+
+    @Test
+    fun addMemberStoresInOrder() {
+        val c = NakshaCollection("my_coll")
+        c.addMember(CustomMember("a", CustomMemberType.INT32))
+        c.addMember(CustomMember("b", CustomMemberType.STRING))
+        val members = c.members
+        assertNotNull(members)
+        assertEquals(2, members.size)
+        assertEquals("a", members[0]!!.name)
+        assertEquals("b", members[1]!!.name)
+    }
+
+    @Test
+    fun addMemberCapsAt64() {
+        val c = NakshaCollection("my_coll")
+        for (i in 0 until CustomMemberList.MAX_MEMBERS) {
+            c.addMember(CustomMember("m$i", CustomMemberType.INT32))
+        }
+        assertFailsWith<NakshaException> { c.addMember(CustomMember("over", CustomMemberType.INT32)) }
+    }
+
+    @Test
+    fun addCustomIndexRejectsDuplicateName() {
+        val c = NakshaCollection("my_coll")
+        c.addCustomIndex(CustomIndex("idx1", CustomIndexType.BTREE, "id"))
+        assertFailsWith<NakshaException> {
+            c.addCustomIndex(CustomIndex("idx1", CustomIndexType.SPATIAL, "geo"))
+        }
+    }
+
+    @Test
+    fun customIndexTypesExist() {
+        assertNotNull(CustomIndexType.BTREE)
+        assertNotNull(CustomIndexType.SPATIAL)
+        assertNotNull(CustomIndexType.FLAT_MAP)
+    }
+
+    @Test
+    fun customMemberTypesCoverPrimitivesAndVirtuals() {
+        // Primitives.
+        assertNotNull(CustomMemberType.BOOLEAN)
+        assertNotNull(CustomMemberType.INT8)
+        assertNotNull(CustomMemberType.INT16)
+        assertNotNull(CustomMemberType.INT32)
+        assertNotNull(CustomMemberType.INT64)
+        assertNotNull(CustomMemberType.FLOAT32)
+        assertNotNull(CustomMemberType.FLOAT64)
+        assertNotNull(CustomMemberType.STRING)
+        assertNotNull(CustomMemberType.BYTE_ARRAY)
+        // Virtual.
+        assertNotNull(CustomMemberType.FLAT_MAP)
+        assertNotNull(CustomMemberType.TAGS)
+    }
+}

--- a/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/TupleNumberQueryTest.kt
+++ b/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/TupleNumberQueryTest.kt
@@ -18,8 +18,8 @@ class TupleNumberQueryTest {
     fun shouldStoreTnsAsByteArray() {
         // Given:
         val serializedTupleNumbers: Array<ByteArray> = arrayOf(
-            randomTupleNumber().toByteArray(TupleNumberVariant.B96),
-            randomTupleNumber().toByteArray(TupleNumberVariant.B96)
+            randomTupleNumber().toByteArray(TupleNumberVariant.B64),
+            randomTupleNumber().toByteArray(TupleNumberVariant.B64)
         )
         val metaQuery = MetaQuery(MetaColumn.nextVersion(), AnyOp.IS_ANY_OF, serializedTupleNumbers)
 
@@ -33,7 +33,6 @@ class TupleNumberQueryTest {
             mapNumber = random.nextInt(10),
             collectionNumber = random.nextInt(10),
             featureNumber = Int64(random.nextInt(10)),
-            version = Version(Int64(random.nextInt(10))),
-            uid = random.nextInt(10)
+            version = Version(Int64(random.nextInt(10)))
         )
 }

--- a/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/TupleNumberTest.kt
+++ b/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/TupleNumberTest.kt
@@ -1,7 +1,11 @@
 package naksha.model
 
 import naksha.base.Int64
-import naksha.model.TupleNumberVariant.*
+import naksha.model.TupleNumberVariant.TupleNumberVariant_C.B64
+import naksha.model.TupleNumberVariant.TupleNumberVariant_C.B128
+import naksha.model.TupleNumberVariant.TupleNumberVariant_C.B160
+import naksha.model.TupleNumberVariant.TupleNumberVariant_C.B192
+import naksha.model.TupleNumberVariant.TupleNumberVariant_C.B256
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/here-naksha-lib-model/src/jvmTest/kotlin/naksha/model/PropertyFilterTest.kt
+++ b/here-naksha-lib-model/src/jvmTest/kotlin/naksha/model/PropertyFilterTest.kt
@@ -468,8 +468,7 @@ class PropertyFilterTest {
                 mapNumber,
                 collectionNumber,
                 featureNumber(feature.id),
-                version,
-                0
+                version
             )
             val tuple = Tuple(
                 meta = Metadata(

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/LibPsql.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/LibPsql.kt
@@ -60,6 +60,11 @@ internal const val PG_META = "${PG_S}meta"
 internal const val PG_IDX = "${PG_S}i_"
 
 /**
+ * `$ci_???`: The prefix used for user-defined (custom) indices, followed by the index identifier, e.g. `$ci_my_idx`.
+ */
+internal const val PG_CUSTOM_IDX = "${PG_S}ci_"
+
+/**
  * `$c_??`: The prefix used for constraints, followed by the identifier of the constraint.
  */
 internal const val PG_CONSTRAINT = "${PG_S}c_"

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCollection.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCollection.kt
@@ -170,4 +170,129 @@ FOR EACH ROW EXECUTE FUNCTION naksha_trigger_after();"""
             )
         }
     }
+
+    /**
+     * Diff the [prev] and [next] collection definitions and apply the resulting schema changes (ADD/DROP COLUMN, CREATE/DROP custom index) to all variant tables (HEAD, HISTORY, DELETED, META).
+     *
+     * Members:
+     * - Same name + same `dataType` → no-op.
+     * - Same name + different `dataType` → throws [NakshaError.ILLEGAL_ARGUMENT] (type changes are not supported).
+     * - Added → `ALTER TABLE ADD COLUMN` on each root variant.
+     * - Removed → requires [force] = `true`; otherwise throws [NakshaError.ILLEGAL_ARGUMENT]. With `force`, emits `ALTER TABLE DROP COLUMN` on each root variant.
+     *
+     * Custom indexes:
+     * - Identity is `(name, type, on, include, unique)`. Any difference → drop + create.
+     *
+     * Only root tables are touched; partition tables inherit `ADD/DROP COLUMN` via Postgres declarative partitioning.
+     *
+     * @since 3.0
+     */
+    internal fun applyMembersAndIndexes(
+        conn: PgConnection,
+        prev: NakshaCollection,
+        next: NakshaCollection,
+        force: Boolean
+    ) {
+        diffMembers(conn, prev, next, force)
+        diffIndexes(conn, prev, next)
+    }
+
+    private fun diffMembers(conn: PgConnection, prev: NakshaCollection, next: NakshaCollection, force: Boolean) {
+        val prevMembers = prev.members
+        val nextMembers = next.members
+        val prevByName = mutableMapOf<String, naksha.model.objects.CustomMember>()
+        val nextByName = mutableMapOf<String, naksha.model.objects.CustomMember>()
+        if (prevMembers != null) for (m in prevMembers) if (m != null) prevByName[m.name] = m
+        if (nextMembers != null) for (m in nextMembers) if (m != null) nextByName[m.name] = m
+
+        // Type-change check.
+        for ((name, nm) in nextByName) {
+            val pm = prevByName[name] ?: continue
+            if (pm.dataType != nm.dataType) {
+                throw naksha.model.illegalArg(
+                    "Change of dataType for member '$name' is not supported (was ${pm.dataType}, requested ${nm.dataType})"
+                )
+            }
+        }
+
+        // Added.
+        for ((name, nm) in nextByName) {
+            if (prevByName.containsKey(name)) continue
+            val pgIdent = "\"${PgCustomMemberValues.pgColumnName(name)}\""
+            val pgType = PgCustomMemberValues.pgSqlTypeFor(nm.dataType)
+            for (root in mutableRootTables()) {
+                val sql = "ALTER TABLE ${root.quotedName} ADD COLUMN IF NOT EXISTS $pgIdent $pgType"
+                conn.execute(sql).close()
+            }
+        }
+
+        // Removed.
+        for ((name, _) in prevByName) {
+            if (nextByName.containsKey(name)) continue
+            if (!force) {
+                throw naksha.model.illegalArg(
+                    "Member '$name' is being removed from collection '$id', but Write.force is false. " +
+                        "Set Write.force = true to allow ALTER TABLE DROP COLUMN."
+                )
+            }
+            val pgIdent = "\"${PgCustomMemberValues.pgColumnName(name)}\""
+            for (root in mutableRootTables()) {
+                val sql = "ALTER TABLE ${root.quotedName} DROP COLUMN IF EXISTS $pgIdent"
+                conn.execute(sql).close()
+            }
+        }
+    }
+
+    private fun diffIndexes(conn: PgConnection, prev: NakshaCollection, next: NakshaCollection) {
+        val prevIdx = prev.indices
+        val nextIdx = next.indices
+        val prevByName = mutableMapOf<String, naksha.model.objects.CustomIndex>()
+        val nextByName = mutableMapOf<String, naksha.model.objects.CustomIndex>()
+        if (prevIdx != null) for (ci in prevIdx) if (ci != null) prevByName[ci.name] = ci
+        if (nextIdx != null) for (ci in nextIdx) if (ci != null) nextByName[ci.name] = ci
+
+        // Removed (or changed): drop on every root.
+        for ((name, pi) in prevByName) {
+            val ni = nextByName[name]
+            if (ni == null || !customIndexEquals(pi, ni)) {
+                for (root in mutableRootTables()) root.dropCustomIndex(conn, name)
+            }
+        }
+
+        // Added (or changed): create on every root.
+        for ((name, ni) in nextByName) {
+            val pi = prevByName[name]
+            if (pi == null || !customIndexEquals(pi, ni)) {
+                for (root in mutableRootTables()) root.createCustomIndex(conn, ni)
+            }
+        }
+    }
+
+    private fun customIndexEquals(a: naksha.model.objects.CustomIndex, b: naksha.model.objects.CustomIndex): Boolean {
+        if (a.name != b.name) return false
+        if (a.type != b.type) return false
+        if (a.unique != b.unique) return false
+        if (!listsEqual(a.on, b.on)) return false
+        if (!listsEqual(a.include, b.include)) return false
+        return true
+    }
+
+    private fun listsEqual(a: naksha.base.StringList?, b: naksha.base.StringList?): Boolean {
+        if (a == null && b == null) return true
+        if (a == null || b == null) return a?.isEmpty() ?: b?.isEmpty() ?: true
+        if (a.size != b.size) return false
+        for (i in 0 until a.size) {
+            if (a[i] != b[i]) return false
+        }
+        return true
+    }
+
+    private fun mutableRootTables(): List<PgTable> {
+        val result = mutableListOf<PgTable>()
+        result.add(headTable)
+        deletedTable?.let { result.add(it) }
+        historyTable?.let { result.add(it) }
+        metaTable?.let { result.add(it) }
+        return result
+    }
 }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgColumnRows.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgColumnRows.kt
@@ -261,6 +261,35 @@ internal class PgColumnRows {
         return false
     }
     fun set(row: Int, column: PgColumn, value: Any?): Boolean = set(row, column.name, value)
+    /**
+     * Adds one [PgColumnEntry] per declared [naksha.model.objects.CustomMember].
+     *
+     * Idempotent — built-in names are never re-added by addColumns(allColumns), and members are checked individually.
+     */
+    fun addCustomMembers(members: naksha.model.objects.CustomMemberList?): PgColumnRows {
+        if (members == null) return this
+        for (m in members) {
+            if (m == null) continue
+            addColumn(PgCustomMemberValues.pgColumnName(m.name), PgCustomMemberValues.pgTypeFor(m.dataType))
+        }
+        return this
+    }
+
+    /**
+     * Populates the [CustomMember][naksha.model.objects.CustomMember] columns for the given row by walking the [feature] using each member's [path][naksha.model.objects.CustomMember.effectivePath] and coercing the value to the SQL type.
+     *
+     * Missing keys and mismatched types both produce a NULL column value. Mismatches additionally emit a warning via [naksha.base.Platform.PlatformCompanion.logger].
+     */
+    fun setCustomMembers(row: Int, feature: naksha.model.objects.NakshaFeature?, members: naksha.model.objects.CustomMemberList?) {
+        if (feature == null || members == null) return
+        for (m in members) {
+            if (m == null) continue
+            val raw = PgCustomMemberValues.walkFeature(feature, m.effectivePath())
+            val coerced = PgCustomMemberValues.coerce(raw, m.dataType, feature.id, m.name)
+            set(row, PgCustomMemberValues.pgColumnName(m.name), coerced)
+        }
+    }
+
     operator fun set(row: Int, tuple: Tuple) {
         withMinSize(row)
         val meta = tuple.meta

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCustomMemberValues.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCustomMemberValues.kt
@@ -1,0 +1,209 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.psql
+
+import naksha.base.AnyObject
+import naksha.base.Int64
+import naksha.base.Platform.PlatformCompanion.logger
+import naksha.base.Platform.PlatformCompanion.toJSON
+import naksha.model.TagList
+import naksha.model.objects.CustomMember
+import naksha.model.objects.CustomMemberType
+import naksha.model.objects.NakshaFeature
+
+/**
+ * Helpers to map [CustomMember] values from a [NakshaFeature] into a [PgColumnRows] row.
+ *
+ * - [walkFeature]: descend a [NakshaFeature] using the member's path; returns _null_ if the path is missing.
+ * - [coerce]: coerce a raw value to the type of the member; returns _null_ and logs a warning on mismatch.
+ * - [pgTypeFor]: maps a [CustomMemberType] to the [PgType] used for prepared-statement binding.
+ * - [pgSqlTypeFor]: returns the PostgreSQL DDL type for `CREATE TABLE` / `ALTER TABLE ADD COLUMN`.
+ * - [pgColumnName]: returns the physical column name (`$<member.name>`) used in Postgres.
+ */
+internal object PgCustomMemberValues {
+
+    /**
+     * Returns the physical Postgres column name for the given member name. Custom columns are namespaced with `$` so they cannot collide with built-in columns (whose names contain no `$`).
+     */
+    fun pgColumnName(memberName: String): String = "\$$memberName"
+
+    fun pgTypeFor(type: CustomMemberType): PgType = when (type) {
+        CustomMemberType.BOOLEAN -> PgType.BOOLEAN
+        CustomMemberType.INT8 -> PgType.SHORT
+        CustomMemberType.INT16 -> PgType.SHORT
+        CustomMemberType.INT32 -> PgType.INT
+        CustomMemberType.INT64 -> PgType.INT64
+        CustomMemberType.FLOAT32 -> PgType.FLOAT
+        CustomMemberType.FLOAT64 -> PgType.DOUBLE
+        CustomMemberType.STRING -> PgType.STRING
+        CustomMemberType.BYTE_ARRAY -> PgType.BYTE_ARRAY
+        CustomMemberType.FLAT_MAP -> PgType.JSONB
+        CustomMemberType.TAGS -> PgType.JSONB
+        else -> PgType.STRING
+    }
+
+    /**
+     * Returns the PostgreSQL DDL type string for the given member type, used inside `CREATE TABLE` / `ALTER TABLE ADD COLUMN`. Note: there is no 1-byte signed integer type in PostgreSQL, so [CustomMemberType.INT8] is materialized as `smallint`; the storage enforces the 8-bit range on coercion.
+     */
+    fun pgSqlTypeFor(type: CustomMemberType): String = when (type) {
+        CustomMemberType.BOOLEAN -> "boolean"
+        CustomMemberType.INT8 -> "smallint"
+        CustomMemberType.INT16 -> "smallint"
+        CustomMemberType.INT32 -> "integer"
+        CustomMemberType.INT64 -> "bigint"
+        CustomMemberType.FLOAT32 -> "real"
+        CustomMemberType.FLOAT64 -> "double precision"
+        CustomMemberType.STRING -> "text COLLATE \"C\""
+        CustomMemberType.BYTE_ARRAY -> "bytea"
+        CustomMemberType.FLAT_MAP -> "jsonb"
+        CustomMemberType.TAGS -> "jsonb"
+        else -> "text"
+    }
+
+    /**
+     * Returns the comma-prefixed SQL fragment for the [CustomMember.name] / [CustomMember.dataType] used in `CREATE TABLE`. Example: `"$age" smallint`.
+     */
+    fun sqlDefinitionFor(member: CustomMember): String =
+        "\"${pgColumnName(member.name)}\" ${pgSqlTypeFor(member.dataType)}"
+
+    fun walkFeature(feature: NakshaFeature, path: List<String>): Any? {
+        var current: Any? = feature
+        for (segment in path) {
+            if (current == null) return null
+            current = when (current) {
+                is AnyObject -> current.getRaw(segment)
+                else -> return null
+            }
+        }
+        return current
+    }
+
+    fun coerce(value: Any?, type: CustomMemberType, featureId: String, memberName: String): Any? {
+        if (value == null) return null
+        return when (type) {
+            CustomMemberType.BOOLEAN -> coerceBoolean(value, featureId, memberName)
+            CustomMemberType.INT8 -> coerceInt8(value, featureId, memberName)
+            CustomMemberType.INT16 -> coerceInt16(value, featureId, memberName)
+            CustomMemberType.INT32 -> coerceInt32(value, featureId, memberName)
+            CustomMemberType.INT64 -> coerceInt64(value, featureId, memberName)
+            CustomMemberType.FLOAT32 -> coerceFloat32(value, featureId, memberName)
+            CustomMemberType.FLOAT64 -> coerceFloat64(value, featureId, memberName)
+            CustomMemberType.STRING -> coerceString(value, featureId, memberName)
+            CustomMemberType.BYTE_ARRAY -> coerceByteArray(value, featureId, memberName)
+            CustomMemberType.FLAT_MAP -> coerceFlatMap(value, featureId, memberName)
+            CustomMemberType.TAGS -> coerceTags(value, featureId, memberName)
+            else -> {
+                warnMismatch(featureId, memberName, type.toString(), value)
+                null
+            }
+        }
+    }
+
+    private fun coerceBoolean(value: Any, featureId: String, memberName: String): Boolean? = when (value) {
+        is Boolean -> value
+        else -> { warnMismatch(featureId, memberName, "boolean", value); null }
+    }
+
+    private fun coerceInt8(value: Any, featureId: String, memberName: String): Short? {
+        val asLong = numberToLongOrNull(value) ?: return null.also { warnMismatch(featureId, memberName, "int8", value) }
+        if (asLong !in Byte.MIN_VALUE.toLong()..Byte.MAX_VALUE.toLong()) {
+            warnMismatch(featureId, memberName, "int8 (out of range)", value)
+            return null
+        }
+        return asLong.toShort()
+    }
+
+    private fun coerceInt16(value: Any, featureId: String, memberName: String): Short? {
+        val asLong = numberToLongOrNull(value) ?: return null.also { warnMismatch(featureId, memberName, "int16", value) }
+        if (asLong !in Short.MIN_VALUE.toLong()..Short.MAX_VALUE.toLong()) {
+            warnMismatch(featureId, memberName, "int16 (out of range)", value)
+            return null
+        }
+        return asLong.toShort()
+    }
+
+    private fun coerceInt32(value: Any, featureId: String, memberName: String): Int? {
+        val asLong = numberToLongOrNull(value) ?: return null.also { warnMismatch(featureId, memberName, "int32", value) }
+        if (asLong !in Int.MIN_VALUE.toLong()..Int.MAX_VALUE.toLong()) {
+            warnMismatch(featureId, memberName, "int32 (out of range)", value)
+            return null
+        }
+        return asLong.toInt()
+    }
+
+    private fun coerceInt64(value: Any, featureId: String, memberName: String): Int64? = when (value) {
+        is Int64 -> value
+        is Int -> Int64(value.toLong())
+        is Long -> Int64(value)
+        is Short -> Int64(value.toLong())
+        is Byte -> Int64(value.toLong())
+        is Double -> if (value.isFinite() && value == value.toLong().toDouble()) Int64(value.toLong()) else { warnMismatch(featureId, memberName, "int64", value); null }
+        is Float -> if (value.isFinite() && value == value.toLong().toFloat()) Int64(value.toLong()) else { warnMismatch(featureId, memberName, "int64", value); null }
+        else -> { warnMismatch(featureId, memberName, "int64", value); null }
+    }
+
+    private fun coerceFloat32(value: Any, featureId: String, memberName: String): Float? = when (value) {
+        is Float -> value
+        is Double -> value.toFloat()
+        is Int -> value.toFloat()
+        is Long -> value.toFloat()
+        is Int64 -> value.toLong().toFloat()
+        is Short -> value.toFloat()
+        is Byte -> value.toFloat()
+        else -> { warnMismatch(featureId, memberName, "float32", value); null }
+    }
+
+    private fun coerceFloat64(value: Any, featureId: String, memberName: String): Double? = when (value) {
+        is Double -> value
+        is Float -> value.toDouble()
+        is Int -> value.toDouble()
+        is Long -> value.toDouble()
+        is Int64 -> value.toLong().toDouble()
+        is Short -> value.toDouble()
+        is Byte -> value.toDouble()
+        else -> { warnMismatch(featureId, memberName, "float64", value); null }
+    }
+
+    private fun coerceString(value: Any, featureId: String, memberName: String): String? = when (value) {
+        is String -> value
+        else -> { warnMismatch(featureId, memberName, "string", value); null }
+    }
+
+    private fun coerceByteArray(value: Any, featureId: String, memberName: String): ByteArray? = when (value) {
+        is ByteArray -> value
+        else -> { warnMismatch(featureId, memberName, "byte_array", value); null }
+    }
+
+    private fun coerceFlatMap(value: Any, featureId: String, memberName: String): String? {
+        if (value !is AnyObject) {
+            warnMismatch(featureId, memberName, "flat_map", value)
+            return null
+        }
+        return try { toJSON(value) } catch (_: Exception) { warnMismatch(featureId, memberName, "flat_map", value); null }
+    }
+
+    private fun coerceTags(value: Any, featureId: String, memberName: String): String? {
+        val tagList = when (value) {
+            is TagList -> value
+            is AnyObject -> value.proxy(TagList::class)
+            else -> { warnMismatch(featureId, memberName, "tags", value); return null }
+        }
+        val tagMap = tagList.toTagMap()
+        return try { toJSON(tagMap) } catch (_: Exception) { warnMismatch(featureId, memberName, "tags", value); null }
+    }
+
+    private fun numberToLongOrNull(value: Any): Long? = when (value) {
+        is Byte -> value.toLong()
+        is Short -> value.toLong()
+        is Int -> value.toLong()
+        is Long -> value
+        is Int64 -> value.toLong()
+        is Float -> if (value.isFinite() && value == value.toLong().toFloat()) value.toLong() else null
+        is Double -> if (value.isFinite() && value == value.toLong().toDouble()) value.toLong() else null
+        else -> null
+    }
+
+    private fun warnMismatch(featureId: String, memberName: String, expected: String, value: Any) {
+        logger.warn("Custom member '$memberName' on feature '$featureId': expected $expected, got ${value::class.simpleName}")
+    }
+}

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgMap.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgMap.kt
@@ -148,19 +148,11 @@ open class PgMap internal constructor(
     open fun createPgCollection(conn: PgConnection, collection: PgCollection) {
         // Ensure that all tables and indices are created in the correct map!
         setSearchPath(conn)
-        val indices: List<PgIndex>
-        val indexNames = collection.head.indices ?: PgIndex.DEFAULT_INDICES
-        indices = mutableListOf()
-        for (indexName in indexNames) {
-            if (indexName == null) continue
-            val index = PgIndex.of(indexName.toString())
-            if (index != null
-                && !indices.contains(index)
-                && !index.internal) {
-                indices.add(index)
-            }
-        }
+        // Default built-in optional indexes are always applied; user-defined indices come from collection.head.indices.
+        val indices: List<PgIndex> = PgIndex.DEFAULT_INDICES.filter { !it.internal }
         val NOW = Epoch()
+
+        val customIndexes = collection.head.indices
 
         if (collection is PgNakshaTransactions) {
             val txn = PgTransactions(collection)
@@ -173,6 +165,7 @@ open class PgMap internal constructor(
             for (index in indices) {
                 txn.createIndex(conn, index)
             }
+            if (customIndexes != null) for (ci in customIndexes) if (ci != null) txn.createCustomIndex(conn, ci)
 
             // We can have a meta table for transactions, but no history or deleted!
             if (collection.metaTable != null) {
@@ -184,6 +177,7 @@ open class PgMap internal constructor(
                 for (index in indices) {
                     meta.createIndex(conn, index)
                 }
+                if (customIndexes != null) for (ci in customIndexes) if (ci != null) meta.createCustomIndex(conn, ci)
             }
             return
         }
@@ -196,6 +190,7 @@ open class PgMap internal constructor(
         for (index in indices) {
             head.createIndex(conn, index)
         }
+        if (customIndexes != null) for (ci in customIndexes) if (ci != null) head.createCustomIndex(conn, ci)
 
         val deleted = collection.deletedTable
         if (deleted != null) {
@@ -206,6 +201,7 @@ open class PgMap internal constructor(
             for (index in indices) {
                 deleted.createIndex(conn, index)
             }
+            if (customIndexes != null) for (ci in customIndexes) if (ci != null) deleted.createCustomIndex(conn, ci)
         }
 
         val meta = collection.metaTable
@@ -217,6 +213,7 @@ open class PgMap internal constructor(
             for (index in indices) {
                 meta.createIndex(conn, index)
             }
+            if (customIndexes != null) for (ci in customIndexes) if (ci != null) meta.createCustomIndex(conn, ci)
         }
 
         val history = collection.historyTable
@@ -230,6 +227,7 @@ open class PgMap internal constructor(
             for (index in indices) {
                 history.createIndex(conn, index)
             }
+            if (customIndexes != null) for (ci in customIndexes) if (ci != null) history.createCustomIndex(conn, ci)
         }
         invalidateCollection(collection)
     }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgTable.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgTable.kt
@@ -371,9 +371,9 @@ $TABLESPACE"""
             // HISTORY (this) -> YEARLY
             // HISTORY (this) -> YEARLY -> PARTITION
             val SQL = """$CREATE_TABLE $quotedName (
-${PgColumn.allColumns.joinToString(",\n") { it.sqlDefinition }},
+${PgColumn.allColumns.joinToString(",\n") { it.sqlDefinition }}${extraColumnDefinitions()},
 CONSTRAINT ${quoteIdent(name + PG_TN_NEXT_CONSTRAINT)} CHECK (next_tn IS NOT NULL)
-) PARTITION BY RANGE (naksha_tn_year(next_tn)) 
+) PARTITION BY RANGE (naksha_tn_year(next_tn))
 $TABLESPACE"""
             return Pair(SQL, TABLESPACE)
         }
@@ -382,7 +382,7 @@ $TABLESPACE"""
         if (partitionColumn == null) {
             // HEAD, META, or DELETED.
             val SQL = """$CREATE_TABLE $quotedName (
-${PgColumn.allColumns.joinToString(",\n") { it.sqlDefinition }},
+${PgColumn.allColumns.joinToString(",\n") { it.sqlDefinition }}${extraColumnDefinitions()},
 CONSTRAINT ${quoteIdent(PgIndex.tn_pkey.id(this))} PRIMARY KEY (${PgColumn.tn})
 )
 WITH (fillfactor=100,toast_tuple_target=$toast_tuple_target)
@@ -395,9 +395,9 @@ $TABLESPACE"""
             // HEAD (this) -> PARTITION
             // DELETED (this) -> PARTITION
             val SQL = """$CREATE_TABLE $quotedName (
-${PgColumn.allColumns.joinToString(",\n") { it.sqlDefinition }},
+${PgColumn.allColumns.joinToString(",\n") { it.sqlDefinition }}${extraColumnDefinitions()},
 CONSTRAINT ${quoteIdent(name + PG_TN_NEXT_CONSTRAINT)} CHECK (${if (isDeleted(name)) "next_tn = tn" else "next_tn IS NULL"})
-) PARTITION BY RANGE (naksha_tn_partition_index(tn, $partitionCount)) 
+) PARTITION BY RANGE (naksha_tn_partition_index(tn, $partitionCount))
 $TABLESPACE"""
             return Pair(SQL, TABLESPACE)
         }
@@ -489,6 +489,133 @@ $TABLESPACE"""
             index.drop(conn, this)
             indices = indices - index
         }
+    }
+
+    /**
+     * Returns the SQL fragment with extra column definitions for user-declared [members][naksha.model.objects.NakshaCollection.members].
+     *
+     * The result is empty when there are no members, otherwise it is comma-prefixed and ready to be appended to the built-in column list in `CREATE TABLE`.
+     */
+    internal fun extraColumnDefinitions(): String {
+        val members = collection.head.members ?: return ""
+        if (members.isEmpty()) return ""
+        val sb = StringBuilder()
+        for (member in members) {
+            if (member == null) continue
+            sb.append(",\n").append(PgCustomMemberValues.sqlDefinitionFor(member))
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Returns the unique identifier for a user-defined index on this table.
+     *
+     * The result follows the pattern `{table-name}$ci_{index-name}` and is truncated to 63 bytes (Postgres identifier limit).
+     */
+    internal fun customIndexId(indexName: String): String {
+        val id = "${name}${PG_CUSTOM_IDX}${indexName}"
+        return if (id.length > 63) id.substring(0, 63) else id
+    }
+
+    /**
+     * Creates a [CustomIndex][naksha.model.objects.CustomIndex] on this table.
+     *
+     * Internal naming follows `{table-name}$ci_{index.name}`; truncated to Postgres's 63-byte identifier limit.
+     * @param conn the connection to use to execute the creation.
+     * @param index the index to create.
+     */
+    open fun createCustomIndex(conn: PgConnection, index: naksha.model.objects.CustomIndex) {
+        val sql = buildCustomIndexSql(index) ?: return
+        conn.execute(sql).close()
+    }
+
+    /**
+     * Drops a [CustomIndex][naksha.model.objects.CustomIndex] from this table.
+     */
+    open fun dropCustomIndex(conn: PgConnection, indexName: String) {
+        val id = customIndexId(indexName)
+        conn.execute("DROP INDEX IF EXISTS ${quoteIdent(id)} CASCADE").close()
+    }
+
+    private fun buildCustomIndexSql(index: naksha.model.objects.CustomIndex): String? {
+        val on = index.on
+        if (on.isEmpty()) return null
+        val id = quoteIdent(customIndexId(index.name))
+        val unique = if (index.unique) "UNIQUE INDEX" else "INDEX "
+        val fillFactor = if (isVolatile) "WITH (deduplicate_items=OFF, fillfactor=80)" else "WITH (deduplicate_items=OFF, fillfactor=100)"
+        val members = collection.head.members
+        val firstCol = on[0] ?: return null
+        return when (index.type) {
+            naksha.model.objects.CustomIndexType.BTREE -> {
+                val cols = on.filterNotNull().joinToString(", ") { col ->
+                    val pgIdent = quoteIdent(physicalColumnName(col, members))
+                    val opclass = if (isTextColumn(col, members)) " text_pattern_ops" else ""
+                    "$pgIdent$opclass DESC"
+                }
+                val include = index.include?.takeIf { !it.isEmpty() }?.let { inc ->
+                    " INCLUDE (${inc.filterNotNull().joinToString(", ") { quoteIdent(physicalColumnName(it, members)) }})"
+                } ?: ""
+                """
+CREATE $unique IF NOT EXISTS $id ON ${quotedName}
+USING btree ($cols)$include
+$fillFactor ${TABLESPACE};""".trim()
+            }
+            naksha.model.objects.CustomIndexType.SPATIAL -> {
+                if (firstCol != "geo") {
+                    throw naksha.model.illegalArg("SPATIAL custom index '${index.name}' only supports the built-in 'geo' column in v3.0")
+                }
+                val cFlags = PgColumn.flags.ident
+                val cGeo = PgColumn.geo.ident
+                """
+CREATE INDEX  IF NOT EXISTS $id ON ${quotedName}
+USING gist (naksha_2d($cGeo, $cFlags))
+WITH (fillfactor=${if (isVolatile) 80 else 100}) ${TABLESPACE}
+WHERE naksha_2d($cGeo, $cFlags) IS NOT NULL;""".trim()
+            }
+            naksha.model.objects.CustomIndexType.FLAT_MAP -> {
+                if (!isFlatMapColumn(firstCol, members)) {
+                    throw naksha.model.illegalArg("FLAT_MAP custom index '${index.name}' must target a member of dataType FLAT_MAP or TAGS")
+                }
+                val pgIdent = quoteIdent(physicalColumnName(firstCol, members))
+                """
+CREATE INDEX  IF NOT EXISTS $id ON ${quotedName}
+USING gin ($pgIdent)
+$fillFactor ${TABLESPACE};""".trim()
+            }
+            else -> null
+        }
+    }
+
+    private fun physicalColumnName(name: String, members: naksha.model.objects.CustomMemberList?): String {
+        if (members != null) {
+            for (m in members) {
+                if (m != null && m.name == name) return PgCustomMemberValues.pgColumnName(name)
+            }
+        }
+        return name
+    }
+
+    private fun isTextColumn(name: String, members: naksha.model.objects.CustomMemberList?): Boolean {
+        if (members != null) {
+            for (m in members) {
+                if (m != null && m.name == name) {
+                    return m.dataType == naksha.model.objects.CustomMemberType.STRING
+                }
+            }
+        }
+        if (name == "id" || name == "app_id" || name == "author" || name == "ft" || name == "origin" || name == "target") return true
+        return false
+    }
+
+    private fun isFlatMapColumn(name: String, members: naksha.model.objects.CustomMemberList?): Boolean {
+        if (members == null) return false
+        for (m in members) {
+            if (m != null && m.name == name) {
+                return m.dataType == naksha.model.objects.CustomMemberType.FLAT_MAP
+                    || m.dataType == naksha.model.objects.CustomMemberType.TAGS
+            }
+        }
+        return false
     }
 }
 

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgType.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgType.kt
@@ -125,6 +125,16 @@ class PgType : JsEnum() {
         }
 
         /**
+         * JSONB column type, bound as text (JSON).
+         *
+         * Used by storages to materialize [naksha.model.objects.CustomMemberType.FLAT_MAP] and [naksha.model.objects.CustomMemberType.TAGS] members.
+         * @since 3.0
+         */
+        @JvmField
+        @JsStatic
+        val JSONB = defIgnoreCase(PgType::class, "jsonb")
+
+        /**
          * Returns the [PgType] from the given string.
          * @param name the name, for example `"int"`.
          * @return the matching [PgType] or `null`, if none matches.

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
@@ -332,6 +332,9 @@ open class PgWriter internal constructor(
                         throw collectionExists(
                             "The write #${write.i} failed, because the collection '$featureId' does exist already in map '$mapId'"
                         )
+                    } else {
+                        // UPSERT or UPDATE on an existing collection: diff schema (members + custom indexes) and apply.
+                        pgCollection.applyMembersAndIndexes(conn, pgCollection.head, nakshaCollection, write.original.force)
                     }
                 } else if (op == WriteOp.DELETE || op == WriteOp.PURGE) {
                     if (pgCollection != null) {

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterInsert.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterInsert.kt
@@ -15,11 +15,15 @@ internal class PgWriterInsert(writer: PgWriter, collection: PgCollection, partit
 {
     init {
         inRows.addColumns(allColumns)
+        val members = collection.head.members
+        inRows.addCustomMembers(members)
         var i = 0
         for (write in writes) {
             val tuple = write.tuple
             if (tuple != null) {
-                inRows[i++] = tuple
+                inRows[i] = tuple
+                inRows.setCustomMembers(i, write.feature, members)
+                i++
             }
         }
     }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterUpdate.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterUpdate.kt
@@ -21,6 +21,8 @@ internal class PgWriterUpdate(writer: PgWriter, collection: PgCollection, partit
     init {
         inRows.addColumns(allColumns)
         inRows.addColumn("version", PgType.INT64) // needed to do atomic updates
+        val members = collection.head.members
+        inRows.addCustomMembers(members)
         var i = 0
         for (write in writes) {
             val tuple = write.tuple
@@ -28,6 +30,7 @@ internal class PgWriterUpdate(writer: PgWriter, collection: PgCollection, partit
                 writeById[write.id] = write
                 inRows[i] = tuple
                 inRows.set(i, "version", write.version?.txn)
+                inRows.setCustomMembers(i, write.feature, members)
                 i++
             }
         }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterUpsert.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterUpsert.kt
@@ -19,12 +19,16 @@ internal class PgWriterUpsert(writer: PgWriter, collection: PgCollection, partit
 
     init {
         inRows.addColumns(allColumns)
+        val members = collection.head.members
+        inRows.addCustomMembers(members)
         var i = 0
         for (write in writes) {
             val tuple = write.tuple
             if (tuple != null) {
-                inRows[i++] = tuple
+                inRows[i] = tuple
+                inRows.setCustomMembers(i, write.feature, members)
                 writeByTn[tuple.tupleNumber] = write
+                i++
             }
         }
     }

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/CollectionTests.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/CollectionTests.kt
@@ -121,7 +121,7 @@ class CollectionTests : PgTestBase(collection = null, mapId = "") {
             CS2_IDX,
             CS3_IDX,
         )
-        collection.withIndices(indices)
+        // The closed-enum opt-in list was removed; PgMap.createPgCollection always applies PgIndex.DEFAULT_INDICES.
         executeWrite(
             WriteRequest().add(
                 Write().createCollection(collection)

--- a/here-naksha-lib-psql/src/jvmTest/kotlin/naksha/psql/Plv8PerfTest.kt
+++ b/here-naksha-lib-psql/src/jvmTest/kotlin/naksha/psql/Plv8PerfTest.kt
@@ -41,7 +41,7 @@ class Plv8PerfTest : PgTestBase(
         partitions = NUM_OF_PARTITIONS,
         storeHistory = StoreMode.ON,
         storeDeleted = StoreMode.ON
-    ).withIndices(ID_IDX, GIST_IDX, TAGS_IDX, HERE_TILE_IDX)//.withIndices(ID_IDX)
+    )// closed-enum opt-in list removed; default indices applied automatically
 ) {
     companion object {
         val featureSource = JSON_TOPOLOGY_SMALL


### PR DESCRIPTION
Introduces `NakshaCollection.members` (typed user-defined columns) and `NakshaCollection.indices` (replaces the legacy StringList opt-in list of built-in indexes). At write time, the storage walks each feature using the member's JsonPath (defaults to ["properties", name]), coerces the value to the declared CustomMemberType, and stores it in a real Postgres column namespaced with `$` (`$age`, `$price`, ...) to avoid collision with built-ins. The value also remains in the encoded feature blob.

CustomMemberType (model-only, no SQL flavor):
  BOOLEAN, INT8/16/32/64, FLOAT32/64, STRING, BYTE_ARRAY,
  FLAT_MAP (object of primitives), TAGS (string-array expanded to flat map).

CustomIndexType: BTREE, SPATIAL, FLAT_MAP.

Schema mutability runs on UPSERT/UPDATE of an existing collection:
  - same name + same dataType -> no-op
  - same name + different dataType -> ILLEGAL_ARGUMENT (no type change)
  - new member -> ALTER TABLE ADD COLUMN on HEAD/HISTORY/DELETED/META roots (nullable, no default - metadata-only on PG 11+)
  - removed member -> requires Write.force=true; ALTER TABLE DROP COLUMN
  - index identity = (name, type, on, include, unique); any diff -> drop+create

PgIndex.DEFAULT_INDICES is now always applied; the closed-enum opt-in via `indices: StringList` is removed.

Naming:
  - Member/index names use the standard Naksha.verifyId rules (no new regex or MAX_LENGTH).
  - Physical PG column is `$<name>` so user names cannot collide with the built-in column namespace.