### PR TITLE
SET implementation for tags

### DIFF
--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Naksha.kt
@@ -481,8 +481,8 @@ class Naksha private constructor() {
             val feature = decodeFeature(tuple.feature, dataEncoding, dictReader) ?: NakshaFeature()
             feature.properties.xyz = XyzNs.fromTuple(tuple)
             val xyz = feature.properties.xyz
-            val tags = tuple.getTags(naksha.model.objects.StandardMembers.Tags)
-            if (tags != null) xyz.tags = tags.toTagList()
+            val tags = tuple.getTagList(naksha.model.objects.StandardMembers.Tags)
+            if (tags != null) xyz.tags = tags
             val geo = tuple.getByteArray(naksha.model.objects.StandardMembers.Geometry)
             if (geo != null) feature.geometry = decodeGeometry(geo)
             return feature
@@ -535,7 +535,7 @@ class Naksha private constructor() {
             val featureBytes = encodeFeature(feature, encoding, dict)
             val geoBytes = encodeGeometry(feature.geometry)
             val refPoint = encodeGeometry(feature.referencePoint)
-            val tagsJson = encodeTags(xyz.tags.toTagMap())
+            val tagsJson = encodeTagList(xyz.tags)
             members.put("geo", geoBytes)
             members.put("ref_point", refPoint)
             members.put("tags", tagsJson)
@@ -596,7 +596,7 @@ class Naksha private constructor() {
             val featureBytes = encodeFeature(feature, encoding, dict)
             val geoBytes = encodeGeometry(feature.geometry)
             val refPoint = encodeGeometry(feature.referencePoint)
-            val tagsJson = encodeTags(xyz.tags.toTagMap())
+            val tagsJson = encodeTagList(xyz.tags)
             members.put("geo", geoBytes)
             members.put("ref_point", refPoint)
             members.put("tags", tagsJson)
@@ -711,6 +711,43 @@ class Naksha private constructor() {
         fun encodeTags(tags: TagMap?): String? {
             if (tags.isNullOrEmpty()) return null
             return toJSON(tags)
+        }
+
+        /**
+         * Encodes the given tag-list into the [set][naksha.model.objects.MemberType.SET]
+         * representation: a JSON array, with the element order preserved.
+         * @param tags the tags to encode.
+         * @return the JSON array text representation, or _null_ if [tags] is _null_ / empty.
+         * @since 3.0
+         */
+        @JsStatic
+        @JvmStatic
+        fun encodeTagList(tags: TagList?): String? {
+            if (tags.isNullOrEmpty()) return null
+            return toJSON(tags)
+        }
+
+        /**
+         * Decodes Naksha tags from their JSON text representation into a [TagList].
+         *
+         * Supports both persisted forms:
+         * - a JSON array ([set][naksha.model.objects.MemberType.SET], the default) is returned
+         *   unmodified, preserving the element order;
+         * - a JSON object ([naksha.model.objects.MemberType.TAGS_FROM_ARRAY]) is re-flattened via
+         *   [TagMap.toTagList], in which case the original order is not guaranteed.
+         * @param json the JSON text to decode (value of the `tags` member).
+         * @return the decoded tag-list, or _null_ if [json] is _null_, blank, or neither an array nor an object.
+         * @since 3.0
+         */
+        @JsStatic
+        @JvmStatic
+        fun decodeTagList(json: String?): TagList? {
+            if (json.isNullOrBlank()) return null
+            return when (val decoded = fromJSON(json)) {
+                is PlatformList -> decoded.proxy(TagList::class)
+                is PlatformMap -> decoded.proxy(TagMap::class).toTagList()
+                else -> null
+            }
         }
 
         /**

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/StorageTx.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/StorageTx.kt
@@ -190,7 +190,7 @@ open class StorageTx private constructor(
         val featureBytes = Naksha.encodeFeature(feature, dataEncoding, dict)
         val geoBytes = Naksha.encodeGeometry(feature.geometry)
         val refPoint = Naksha.encodeGeometry(feature.referencePoint)
-        val tagsJson = Naksha.encodeTags(xyz.tags.toTagMap())
+        val tagsJson = Naksha.encodeTagList(xyz.tags)
         if (members is naksha.jbon.HeapBook) {
             members.put("geo", geoBytes)
             members.put("ref_point", refPoint)

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Tuple.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/Tuple.kt
@@ -257,6 +257,19 @@ data class Tuple(
     }
 
     /**
+     * Get a tags member by name as a [TagList].
+     * Decodes the JSON text, supporting both persisted forms: a JSON array
+     * ([set][naksha.model.objects.MemberType.SET], the default — order preserved) and a JSON object
+     * ([naksha.model.objects.MemberType.TAGS_FROM_ARRAY] — re-flattened, order not guaranteed).
+     * Returns `null` if the member is missing, the value is `null`, or not a String.
+     * @since 3.0
+     */
+    fun getTagList(member: Member): TagList? {
+        val json = members?.getByName(member.name) as? String ?: return null
+        return try { Naksha.decodeTagList(json) } catch (_: Exception) { null }
+    }
+
+    /**
      * The [DataEncoding] of this tuple, read from [members].
      * Returns [Naksha.DEFAULT_DATA_ENCODING] if not set.
      * @since 3.0
@@ -275,9 +288,9 @@ data class Tuple(
     fun toNakshaFeature(): NakshaFeature? {
         val feature = Naksha.decodeFeature(this.feature, dataEncoding, null) ?: return null
         feature.properties.xyz = XyzNs.fromTuple(this)
-        val tags = getTags(StandardMembers.Tags)
+        val tags = getTagList(StandardMembers.Tags)
         if (tags != null) {
-            feature.properties.xyz.tags = tags.toTagList()
+            feature.properties.xyz.tags = tags
         }
         val geoBytes = getByteArray(StandardMembers.Geometry)
         if (geoBytes != null) {

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/Index.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/Index.kt
@@ -20,6 +20,7 @@ import kotlin.js.JsName
  * - [IndexType.BTREE]: ordered index for equality and range queries on scalar and text columns.
  * - [IndexType.SPATIAL]: spatial index covering a 2D-encoded geometry column. [on] must contain exactly one geometry member.
  * - [IndexType.TAGS]: inverted index over a tags member ([MemberType.TAGS] or [MemberType.TAGS_FROM_ARRAY]) supporting key/value containment queries. [on] must contain exactly one member.
+ * - [IndexType.SET]: inverted index over a set member ([MemberType.SET]) supporting element containment queries. [on] must contain exactly one member.
  *
  * When [internal] is `true` the index is storage-managed (e.g. primary key, id_unique). The storage
  * injects these into the [NakshaCollection.indices] list; clients must not declare them manually.

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/IndexType.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/IndexType.kt
@@ -14,6 +14,7 @@ import kotlin.reflect.KClass
  * - [SPATIAL] — spatial index over a geometry column (e.g. the built-in `geo`).
  * - [TAGS] — inverted index over a tags column ([MemberType.TAGS] or [MemberType.TAGS_FROM_ARRAY]);
  *   supports key/value containment lookups.
+ * - [SET] — inverted index over a set column ([MemberType.SET]); supports element containment lookups.
  * @since 3.0
  */
 @JsExport
@@ -46,5 +47,14 @@ class IndexType : JsEnum() {
          */
         @JvmField
         val TAGS = defIgnoreCase(IndexType::class, "tags")
+
+        /**
+         * Inverted index over a [MemberType.SET] column. Supports element containment lookups,
+         * e.g. find all features whose tags set contains the element `"foo"`. This is the default
+         * index for the standard `tags` member.
+         * @since 3.0
+         */
+        @JvmField
+        val SET = defIgnoreCase(IndexType::class, "set")
     }
 }

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/MemberType.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/MemberType.kt
@@ -17,11 +17,16 @@ import kotlin.reflect.KClass
  *   The storage persists this as a flat key/value map that supports containment queries.
  * - [TAGS_FROM_ARRAY]: like [TAGS] but the input is a `TagList` (Naksha tag-array syntax, e.g.
  *   `["key=value", "name:=42"]`). The list is converted to a tag-map at write time and stored in the
- *   same flat key/value representation as [TAGS].
- *   This exists for downward compatibility with XYZ Hub and previous Naksha v2 clients that send
- *   tags as arrays rather than maps.
+ *   same flat key/value representation as [TAGS]. Beware that the conversion has a side effect:
+ *   reading the feature back returns the tags re-flattened from the map, so the original array
+ *   order is **not** preserved.
  *   Only valid as a [Member] type; not a valid [IndexType].
  *   To index a [TAGS_FROM_ARRAY] column use [IndexType.TAGS].
+ * - [SET]: a JSON array of unique primitive values (booleans, numbers, strings). The array is stored
+ *   unmodified, so the element order is preserved when reading the feature back. Supports
+ *   element-containment queries via [IndexType.SET]. This is the default type of the standard
+ *   `tags` member, which keeps 100% downward compatibility with the classic XYZ tags array at
+ *   `properties -> @ns:com:here:xyz -> tags`.
  * @since 3.0
  */
 @JsExport
@@ -132,5 +137,22 @@ class MemberType : JsEnum() {
          */
         @JvmField
         val TAGS_FROM_ARRAY = defIgnoreCase(MemberType::class, "tags_from_array")
+
+        /**
+         * A JSON array of unique primitive values (booleans, numbers, strings), following the JBON2
+         * set specification: entries must not be `null` or duplicates, and the order is significant.
+         * The storage persists the array unmodified (as a JSON array in `jsonb`), so the element
+         * order is guaranteed to be preserved when reading the feature back.
+         *
+         * This is the default type of the standard `tags` member (the classic XYZ tags array at
+         * `properties -> @ns:com:here:xyz -> tags`, e.g. `["foo", "bar"]`). In contrast to
+         * [TAGS_FROM_ARRAY] the values are not split into key/value pairs, therefore only full
+         * elements can be searched, not keys or values.
+         *
+         * Indexed via [IndexType.SET].
+         * @since 3.0
+         */
+        @JvmField
+        val SET = defIgnoreCase(MemberType::class, "set")
     }
 }

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaCollection.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaCollection.kt
@@ -340,7 +340,7 @@ open class NakshaCollection() : NakshaFeature() {
     /**
      * The indices to maintain on this collection.
      *
-     * Each [Index] declares a name, an [IndexType] ([IndexType.BTREE] / [IndexType.SPATIAL] / [IndexType.TAGS]), the column(s) to index, an optional include-list (for [IndexType.BTREE]), and a `unique` flag.
+     * Each [Index] declares a name, an [IndexType] ([IndexType.BTREE] / [IndexType.SPATIAL] / [IndexType.TAGS] / [IndexType.SET]), the column(s) to index, an optional include-list (for [IndexType.BTREE]), and a `unique` flag.
      *
      * Indices are applied to every variant of the collection (head, history, deleted, meta) by the storage. Mandatory and default indices are injected by the storage; clients only need to declare additional custom indices here.
      * @since 3.0

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/StandardIndices.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/StandardIndices.kt
@@ -39,7 +39,7 @@ import kotlin.jvm.JvmStatic
  * - [StandardIndices_C.HereTile] — `here_tile`, `fn`, `version`
  * - [StandardIndices_C.AppId] — `app_id`, `updated_at`, `fn`, `version`
  * - [StandardIndices_C.Author] — `author`, `author_ts`, `fn`, `version`
- * - [StandardIndices_C.Tags] — GIN tags index
+ * - [StandardIndices_C.Tags] — GIN set index over the tags
  * - [StandardIndices_C.FeatureType] — `ft`, `fn`, `version`
  * - [StandardIndices_C.CustomValue0] .. [StandardIndices_C.CustomValue3] — custom numeric values
  * - [StandardIndices_C.CustomString0] .. [StandardIndices_C.CustomString3] — custom string values
@@ -168,11 +168,12 @@ class StandardIndices private constructor() {
         val Author = Index("author", IndexType.BTREE, "author", "author_ts", "fn", "version")
 
         /**
-         * `tags` — inverted ([IndexType.TAGS]) index over the `tags` member. Default index.
+         * `tags` — inverted ([IndexType.SET]) index over the `tags` member, supporting element
+         * containment queries. Default index.
          * @since 3.0
          */
         @JvmField @JsStatic
-        val Tags = Index("tags", IndexType.TAGS, "tags")
+        val Tags = Index("tags", IndexType.SET, "tags")
 
         /**
          * `feature_type` — index on `ft`, `fn`, `version` (WHERE `ft IS NOT NULL`). Default index.

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/StandardMembers.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/StandardMembers.kt
@@ -53,7 +53,7 @@ import kotlin.jvm.JvmStatic
  * - [StandardMembers_C.Target] — join target reference
  * - [StandardMembers_C.FeatureType] — feature-type (only stored when it differs from the collection default)
  * - [StandardMembers_C.CustomString0], [StandardMembers_C.CustomString1], [StandardMembers_C.CustomString2], [StandardMembers_C.CustomString3] — custom string values
- * - [StandardMembers_C.Tags] — feature tags (flat key/value map)
+ * - [StandardMembers_C.Tags] — feature tags (set of unique strings, order preserved)
  * - [StandardMembers_C.ReferencePoint] — geometry reference point (TWKB, [MemberType.SPATIAL])
  * - [StandardMembers_C.Geometry] — feature geometry (TWKB, [MemberType.SPATIAL])
  * - [StandardMembers_C.Attachment] — arbitrary binary attachment
@@ -363,12 +363,15 @@ class StandardMembers private constructor() {
         val CustomString3 = Member("cs3", MemberType.STRING)
 
         /**
-         * `tags` — feature tags stored as a flat key/value map. `null` if the feature has no tags.
-         * Supports containment queries via [IndexType.TAGS]. Default member.
+         * `tags` — feature tags, the classic XYZ tags array located at
+         * `properties -> @ns:com:here:xyz -> tags` (e.g. `["foo", "bar"]`), stored as a
+         * [set][MemberType.SET] of unique strings. The array is persisted unmodified, so the
+         * element order is preserved when reading the feature back. `null` if the feature has no
+         * tags. Supports element containment queries via [IndexType.SET]. Default member.
          * @since 3.0
          */
         @JvmField @JsStatic
-        val Tags = Member("tags", MemberType.TAGS)
+        val Tags = Member("tags", MemberType.SET)
 
         /**
          * `ref_point` — geometry reference point (always a single point), stored as TWKB. Used to

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/query/TagExists.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/query/TagExists.kt
@@ -7,6 +7,11 @@ import kotlin.js.JsName
 
 /**
  * Tests if the tag with given name exists, ignoring the value.
+ *
+ * For map-form tags ([naksha.model.objects.MemberType.TAGS] / [naksha.model.objects.MemberType.TAGS_FROM_ARRAY])
+ * this tests if the key exists. For set-form tags ([naksha.model.objects.MemberType.SET], the default)
+ * this tests if the full string element exists, e.g. `TagExists("foo")` matches a feature tagged
+ * `["foo", "bar"]`.
  * @since 3.0.0
  */
 @JsExport

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/query/TagQuery.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/query/TagQuery.kt
@@ -8,8 +8,15 @@ import kotlin.js.JsExport
 
 /**
  * A general form of a tag query without any operation.
+ *
+ * Note: the `TagValueIs*` and [TagValueMatches] queries operate on keys/values and therefore only
+ * match map-form tags ([naksha.model.objects.MemberType.TAGS] /
+ * [naksha.model.objects.MemberType.TAGS_FROM_ARRAY]). Against the default set-form tags
+ * ([naksha.model.objects.MemberType.SET]) the values are never split into key/value pairs; use
+ * [TagExists] or [TagSetContains] to match full elements instead.
  * @since 3.0.0
  * @see TagExists
+ * @see TagSetContains
  * @see TagValueIsBool
  * @see TagValueIsDouble
  * @see TagValueIsNull

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/query/TagSetContains.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/request/query/TagSetContains.kt
@@ -1,0 +1,49 @@
+@file:Suppress("OPT_IN_USAGE")
+
+package naksha.model.request.query
+
+import naksha.base.AnyObject
+import naksha.base.NullableProperty
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
+/**
+ * Tests if a set-form tags member ([naksha.model.objects.MemberType.SET], the default for the
+ * standard `tags` member) contains the given element.
+ *
+ * The element is matched in its type: strings, booleans, and numbers are all supported. For string
+ * elements this is equivalent to [TagExists], which can therefore be used interchangeably; for all
+ * other primitives this query is the only way to search the set.
+ *
+ * Beware that a set stores full elements (the values are never split into key/value pairs), so only
+ * complete elements can be matched: a feature tagged `["foo=bar"]` is found by
+ * `TagSetContains("foo=bar")`, not by `TagSetContains("foo")`.
+ *
+ * This query does **not** match map-form tags ([naksha.model.objects.MemberType.TAGS] or
+ * [naksha.model.objects.MemberType.TAGS_FROM_ARRAY]); use [TagExists] and the `TagValueIs*` queries
+ * for those.
+ * @since 3.0
+ */
+@JsExport
+class TagSetContains() : AnyObject(), ITagQuery {
+
+    /**
+     * Tests if the set-form tags member contains the given element.
+     * @param element the element to test for; must be a primitive (string, boolean, or number).
+     * @since 3.0
+     */
+    @JsName("of")
+    constructor(element: Any?) : this() {
+        this.element = element
+    }
+
+    companion object TagSetContains_C {
+        private val ELEMENT = NullableProperty<TagSetContains, Any>(Any::class)
+    }
+
+    /**
+     * The element to test for; must be a primitive (string, boolean, or number).
+     * @since 3.0
+     */
+    var element by ELEMENT
+}

--- a/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/MemberTest.kt
+++ b/here-naksha-lib-model/src/commonTest/kotlin/naksha/model/MemberTest.kt
@@ -83,6 +83,7 @@ class MemberTest {
         assertNotNull(IndexType.BTREE)
         assertNotNull(IndexType.SPATIAL)
         assertNotNull(IndexType.TAGS)
+        assertNotNull(IndexType.SET)
     }
 
     @Test
@@ -100,5 +101,38 @@ class MemberTest {
         // Virtual / jsonb.
         assertNotNull(MemberType.TAGS)
         assertNotNull(MemberType.TAGS_FROM_ARRAY)
+        assertNotNull(MemberType.SET)
+    }
+
+    @Test
+    fun standardTagsMemberDefaultsToSet() {
+        assertEquals(MemberType.SET, naksha.model.objects.StandardMembers.Tags.dataType)
+        assertEquals(IndexType.SET, naksha.model.objects.StandardIndices.Tags.type)
+    }
+
+    @Test
+    fun tagListEncodesAsJsonArrayPreservingOrder() {
+        val tags = TagList("foo", "bar", "a=b")
+        val json = Naksha.encodeTagList(tags)
+        assertNotNull(json)
+        // Round-trip must preserve the exact element order (set guarantee).
+        val decoded = Naksha.decodeTagList(json)
+        assertNotNull(decoded)
+        assertEquals(listOf("foo", "bar", "a=b"), decoded.filterNotNull())
+    }
+
+    @Test
+    fun decodeTagListSupportsLegacyMapForm() {
+        // TAGS_FROM_ARRAY persists a JSON object; decodeTagList must re-flatten it.
+        val decoded = Naksha.decodeTagList("""{"foo":null,"a":"b","n":5.0}""")
+        assertNotNull(decoded)
+        val elements = decoded.filterNotNull().toSet()
+        assertEquals(setOf("foo", "a=b", "n:=5.0"), elements)
+    }
+
+    @Test
+    fun encodeTagListOfEmptyIsNull() {
+        assertEquals(null, Naksha.encodeTagList(null))
+        assertEquals(null, Naksha.encodeTagList(TagList()))
     }
 }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgColumn.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgColumn.kt
@@ -477,8 +477,13 @@ class PgColumn : JsEnum() {
         }
 
         /**
-         * The [tags][naksha.model.TagMap] of the [tuple][naksha.model.Tuple], stored as raw `jsonb`.
+         * The tags of the [tuple][naksha.model.Tuple], stored as raw `jsonb`.
          *
+         * By default ([naksha.model.objects.MemberType.SET]) this is a JSON array of unique strings
+         * ([naksha.model.TagList]), persisted unmodified so the element order is preserved. When the
+         * tags member is declared as [naksha.model.objects.MemberType.TAGS] or
+         * [naksha.model.objects.MemberType.TAGS_FROM_ARRAY], it is a JSON object
+         * ([naksha.model.TagMap]) instead.
          * @since 3.0
          */
         @JvmField

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCustomMemberValues.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCustomMemberValues.kt
@@ -2,8 +2,11 @@
 
 package naksha.psql
 
+import naksha.base.AnyList
 import naksha.base.AnyObject
 import naksha.base.Int64
+import naksha.base.ListProxy
+import naksha.base.PlatformList
 import naksha.base.Platform.PlatformCompanion.logger
 import naksha.base.Platform.PlatformCompanion.toJSON
 import naksha.model.NakshaError
@@ -68,6 +71,7 @@ internal object PgCustomMemberValues {
         MemberType.SPATIAL -> PgType.BYTE_ARRAY
         MemberType.TAGS -> PgType.JSONB
         MemberType.TAGS_FROM_ARRAY -> PgType.JSONB
+        MemberType.SET -> PgType.JSONB
         else -> PgType.STRING
     }
 
@@ -75,8 +79,9 @@ internal object PgCustomMemberValues {
      * Returns the PostgreSQL DDL type string for the given member type, used inside `CREATE TABLE` / `ALTER TABLE ADD COLUMN`.
      * Note: there is no 1-byte signed integer type in PostgreSQL, so [MemberType.INT8] is materialized as `smallint`;
      * the storage enforces the 8-bit range on coercion.
-     * Both [MemberType.TAGS] and [MemberType.TAGS_FROM_ARRAY] use `jsonb STORAGE MAIN` — compressed inline,
-     * only TOASTed as a last resort.
+     * [MemberType.TAGS], [MemberType.TAGS_FROM_ARRAY], and [MemberType.SET] all use `jsonb STORAGE MAIN` —
+     * compressed inline, only TOASTed as a last resort. The only difference is the JSON shape:
+     * TAGS and TAGS_FROM_ARRAY persist a JSON object, SET persists a JSON array.
      */
     fun pgSqlTypeFor(type: MemberType): String = when (type) {
         MemberType.BOOLEAN -> "boolean"
@@ -91,6 +96,7 @@ internal object PgCustomMemberValues {
         MemberType.SPATIAL -> "bytea STORAGE EXTERNAL"
         MemberType.TAGS -> "jsonb STORAGE MAIN"
         MemberType.TAGS_FROM_ARRAY -> "jsonb STORAGE MAIN"
+        MemberType.SET -> "jsonb STORAGE MAIN"
         else -> "text"
     }
 
@@ -127,6 +133,7 @@ internal object PgCustomMemberValues {
             MemberType.SPATIAL -> coerceByteArray(value, featureId, memberName)
             MemberType.TAGS -> coerceTags(value, featureId, memberName)
             MemberType.TAGS_FROM_ARRAY -> coerceTagsFromArray(value, featureId, memberName)
+            MemberType.SET -> coerceSet(value, featureId, memberName)
             else -> {
                 warnMismatch(featureId, memberName, type.toString(), value)
                 null
@@ -227,6 +234,40 @@ internal object PgCustomMemberValues {
         return try { toJSON(tagMap) } catch (_: Exception) { warnMismatch(featureId, memberName, "tags_from_array", value); null }
     }
 
+    /**
+     * Coerces a [MemberType.SET] value: a JSON array of unique primitives (booleans, numbers, strings).
+     * The array is persisted unmodified (element order preserved). Entries that are `null`, non-primitive,
+     * or duplicates violate the set contract; the value is then not materialized (warning + NULL column).
+     */
+    private fun coerceSet(value: Any, featureId: String, memberName: String): String? {
+        val list: ListProxy<*> = when (value) {
+            is ListProxy<*> -> value
+            is PlatformList -> value.proxy(AnyList::class)
+            else -> { warnMismatch(featureId, memberName, "set", value); return null }
+        }
+        val seen = HashSet<Any>()
+        for (e in list) {
+            if (e == null) {
+                warnMismatch(featureId, memberName, "set (entries must not be null)", "null")
+                return null
+            }
+            if (!isPrimitive(e)) {
+                warnMismatch(featureId, memberName, "set (entries must be primitives)", e)
+                return null
+            }
+            if (!seen.add(e)) {
+                warnMismatch(featureId, memberName, "set (entries must be unique)", e)
+                return null
+            }
+        }
+        return try { toJSON(list) } catch (_: Exception) { warnMismatch(featureId, memberName, "set", list); null }
+    }
+
+    private fun isPrimitive(value: Any): Boolean = when (value) {
+        is String, is Boolean, is Byte, is Short, is Int, is Long, is Int64, is Float, is Double -> true
+        else -> false
+    }
+
     private fun numberToLongOrNull(value: Any): Long? = when (value) {
         is Byte -> value.toLong()
         is Short -> value.toLong()
@@ -245,7 +286,7 @@ internal object PgCustomMemberValues {
      * 2. 4-byte types ([INT32], [FLOAT32]) — next, still fixed-width
      * 3. 1/2-byte types ([INT16], [INT8], [BOOLEAN]) — small fixed-width
      * 4. Variable-length text ([STRING]) — variable but human-readable
-     * 5. Opaque variable-length ([BYTE_ARRAY], [SPATIAL], [TAGS], [TAGS_FROM_ARRAY]) — last
+     * 5. Opaque variable-length ([BYTE_ARRAY], [SPATIAL], [TAGS], [TAGS_FROM_ARRAY], [SET]) — last
      */
     fun columnSortOrder(type: MemberType): Int = when (type) {
         MemberType.INT64   -> 0
@@ -260,7 +301,8 @@ internal object PgCustomMemberValues {
         MemberType.SPATIAL         -> 8
         MemberType.TAGS            -> 9
         MemberType.TAGS_FROM_ARRAY -> 10
-        else -> 11
+        MemberType.SET             -> 11
+        else -> 12
     }
 
     /**

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgIndex.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgIndex.kt
@@ -695,7 +695,9 @@ ${if (where==null) "" else "WHERE $where"};"""
             // Determine index type from the PgIndex columns (heuristic: geo columns → SPATIAL, no columns or btree → BTREE)
             idx.type = when {
                 pgIdx === gist_geo || pgIdx === spgist_geo || pgIdx === ref_point -> IndexType.SPATIAL
-                pgIdx === tags -> IndexType.TAGS
+                // The built-in tags index is a GIN index over the `tags` member, which is a SET
+                // (JSON array of unique strings) by default — matches StandardIndices.Tags.
+                pgIdx === tags -> IndexType.SET
                 else -> IndexType.BTREE
             }
             val cols = naksha.base.StringList()

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgQueryWhereBuilder.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgQueryWhereBuilder.kt
@@ -1,6 +1,8 @@
 package naksha.psql
 
+import naksha.base.AnyList
 import naksha.base.ListProxy
+import naksha.base.Platform.PlatformCompanion.toJSON
 import naksha.geo.HereTile
 import naksha.geo.SpGeometry
 import naksha.model.*
@@ -349,6 +351,7 @@ internal class PgQueryWhereBuilder(private val request: ReadFeatures) {
 
     private fun whereNestedTags(tagQuery: ITagQuery) {
         when (tagQuery) {
+            is TagSetContains -> resolveTagSetContains(tagQuery)
             is TagNot -> not(tagQuery.query, this::whereNestedTags)
             is TagOr -> {
                 if(containsOnlyTagExists(tagQuery)){
@@ -382,6 +385,18 @@ internal class PgQueryWhereBuilder(private val request: ReadFeatures) {
 
     private fun containsOnlyTagExists(container: ListProxy<ITagQuery>): Boolean =
         container.all { it == null || it is TagExists }
+
+    /**
+     * Element containment on a set-form tags column (jsonb array): `tags @> '[<element>]'::jsonb`.
+     * The `@>` operator matches the element in its type (string, boolean, number) and is supported
+     * by the GIN index over the column.
+     */
+    private fun resolveTagSetContains(tagQuery: TagSetContains) {
+        val element = AnyList()
+        element.add(tagQuery.element)
+        val placeholder = placeholderForArg(toJSON(element), PgType.STRING)
+        where.append("$tagsAsJsonb @> $placeholder::jsonb")
+    }
 
     private fun resolveTagNamesArrayOperation(jsonbOperator: String, tagNames: List<String>) {
         val tagKeysArray = tagNames.toTypedArray()

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgTable.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgTable.kt
@@ -757,7 +757,17 @@ WHERE naksha_2d($cCol) IS NOT NULL;""".trim()
                 """
 CREATE INDEX  IF NOT EXISTS $id ON ${quotedName}
 USING gin ($pgIdent)
-$fillFactor ${TABLESPACE};""".trim()
+${TABLESPACE};""".trim()
+            }
+            IndexType.SET -> {
+                if (!isSetColumn(firstCol, members)) {
+                    throw naksha.model.illegalArg("SET custom index '${index.name}' must target a member of dataType SET")
+                }
+                val pgIdent = quoteIdent(physicalColumnName(firstCol, members))
+                """
+CREATE INDEX  IF NOT EXISTS $id ON ${quotedName}
+USING gin ($pgIdent)
+${TABLESPACE};""".trim()
             }
             else -> null
         }
@@ -785,14 +795,28 @@ $fillFactor ${TABLESPACE};""".trim()
     }
 
     private fun isFlatMapColumn(name: String, members: MemberList?): Boolean {
-        if (members == null) return false
-        for (m in members) {
-            if (m != null && m.name == name) {
-                return m.dataType == MemberType.TAGS
-                    || m.dataType == MemberType.TAGS_FROM_ARRAY
+        val type = memberTypeOf(name, members) ?: return false
+        return type == MemberType.TAGS || type == MemberType.TAGS_FROM_ARRAY
+    }
+
+    private fun isSetColumn(name: String, members: MemberList?): Boolean =
+        memberTypeOf(name, members) == MemberType.SET
+
+    /**
+     * Resolves the [MemberType] of a member by name: explicitly declared members take precedence,
+     * otherwise the standard member contract ([StandardMembers.ALL]) is consulted (e.g. the built-in
+     * `tags` member, which is a [MemberType.SET]).
+     */
+    private fun memberTypeOf(name: String, members: MemberList?): MemberType? {
+        if (members != null) {
+            for (m in members) {
+                if (m != null && m.name == name) return m.dataType
             }
         }
-        return false
+        for (sm in naksha.model.objects.StandardMembers.ALL) {
+            if (sm.name == name) return sm.dataType
+        }
+        return null
     }
 
     private fun isSpatialColumn(name: String, members: MemberList?): Boolean {

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgType.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgType.kt
@@ -127,7 +127,7 @@ class PgType : JsEnum() {
         /**
          * JSONB column type, bound as text (JSON).
          *
-         * Used by storages to materialize [naksha.model.objects.MemberType.TAGS] and [naksha.model.objects.MemberType.TAGS_FROM_ARRAY] members.
+         * Used by storages to materialize [naksha.model.objects.MemberType.TAGS], [naksha.model.objects.MemberType.TAGS_FROM_ARRAY] (JSON object), and [naksha.model.objects.MemberType.SET] (JSON array) members.
          * @since 3.0
          */
         @JvmField

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
@@ -516,6 +516,12 @@ open class PgWriter internal constructor(
                                         "but '$firstColName' has type $firstColType."
                                 )
                             }
+                            IndexType.SET -> if (firstColType != MemberType.SET) {
+                                throw illegalArg(
+                                    "SET index '${idx.name}' must target a member of type SET, " +
+                                        "but '$firstColName' has type $firstColType."
+                                )
+                            }
                             else -> if (firstColType == MemberType.SPATIAL) {
                                 throw illegalArg(
                                     "Index '${idx.name}' of type ${idx.type} cannot target SPATIAL member '$firstColName'. " +

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/CollectionTests.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/CollectionTests.kt
@@ -548,6 +548,52 @@ class CollectionTests : PgTestBase(collection = null, mapId = "") {
     }
 
     /**
+     * When a custom [MemberType.SET] member is declared with a [IndexType.SET] index, the collection
+     * must materialize the member as a `jsonb` column and create a GIN index over it.
+     */
+    @Test
+    fun membersSet_shouldCreateJsonbColumnAndGinIndex() {
+        val collection = NakshaCollection("members_set_test", map.id).apply {
+            addMember(Member("labels", MemberType.SET))
+            addIndex(Index("idx_labels", IndexType.SET, "labels"))
+        }
+        executeWrite(WriteRequest().add(Write().createCollection(collection)))
+
+        storage.adminConnection().use { conn ->
+            // Column: materialized as jsonb.
+            var dataType: String? = null
+            conn.execute(
+                "SELECT data_type FROM information_schema.columns WHERE table_schema = $1 AND table_name = $2 AND column_name = $3",
+                arrayOf(map.id, collection.id, PgCustomMemberValues.pgColumnName("labels"))
+            ).use { cursor -> if (cursor.next()) dataType = cursor["data_type"] }
+            assertEquals("jsonb", dataType, "SET member 'labels' must be materialized as jsonb")
+
+            // Index: GIN index over the jsonb column.
+            val customIndexId = "${collection.id}\$ci_idx_labels"
+            var indexDef: String? = null
+            conn.execute(
+                "SELECT indexdef FROM pg_indexes WHERE schemaname = $1 AND tablename = $2 AND indexname = $3",
+                arrayOf(map.id, collection.id, customIndexId)
+            ).use { cursor -> if (cursor.next()) indexDef = cursor["indexdef"] }
+            assertNotNull(indexDef, "SET index '$customIndexId' not found")
+            assertTrue(indexDef!!.contains("USING gin", ignoreCase = true),
+                "SET index must be a GIN index, got: $indexDef")
+        }
+    }
+
+    /**
+     * A [IndexType.SET] index must be rejected when it targets a member that is not a [MemberType.SET].
+     */
+    @Test
+    fun membersSet_indexOnNonSetMemberShouldFail() {
+        val collection = NakshaCollection("members_set_invalid_test", map.id).apply {
+            addMember(Member("score", MemberType.INT64))
+            addIndex(Index("idx_set_score", IndexType.SET, "score"))
+        }
+        executeWriteErrorResponse(WriteRequest().add(Write().createCollection(collection)))
+    }
+
+    /**
      * Verifies that when a collection with custom members of every type is created, the physical
      * column order in both the HEAD table and the HISTORY table follows the standard pattern:
      *
@@ -570,6 +616,7 @@ class CollectionTests : PgTestBase(collection = null, mapId = "") {
             addMember(Member("g_i16",   MemberType.INT16))
             addMember(Member("h_f32",   MemberType.FLOAT32))
             addMember(Member("i_json",  MemberType.TAGS))
+            addMember(Member("j_set",   MemberType.SET))
         }
         executeWrite(WriteRequest().add(Write().createCollection(collection)))
 
@@ -577,7 +624,7 @@ class CollectionTests : PgTestBase(collection = null, mapId = "") {
         // INT64: b_i64 | FLOAT64: c_f64 | INT32: a_i32 | FLOAT32: h_f32 | INT16: g_i16 | INT8: f_i8 | BOOLEAN: e_bool | STRING: z_str | BYTE_ARRAY: d_bytes | FLAT_MAP: i_json
         // Custom columns are slotted into their type bucket after the last standard column of the same group.
         // Buckets with no matching standard column are flushed immediately after the preceding bucket.
-        // Bucket mapping: INT64=0, FLOAT64=1, INT32=2, FLOAT32=3, INT16=4, INT8=5, BOOLEAN=6, STRING=7, BYTE_ARRAY=8, TAGS=9
+        // Bucket mapping: INT64=0, FLOAT64=1, INT32=2, FLOAT32=3, INT16=4, INT8=5, BOOLEAN=6, STRING=7, BYTE_ARRAY=8, TAGS=9, SET=11
         val customByBucket = mapOf(
             0 to listOf("b_i64"),        // INT64 → after gbn
             1 to listOf("c_f64"),        // FLOAT64 → after cv3
@@ -589,6 +636,7 @@ class CollectionTests : PgTestBase(collection = null, mapId = "") {
             7 to listOf("z_str"),        // STRING → after cs3
             8 to listOf("d_bytes"),      // BYTE_ARRAY → after attachment
             9 to listOf("i_json"),       // TAGS → after BYTE_ARRAY group
+            11 to listOf("j_set"),       // SET → after the standard tags column (jsonb bucket)
         )
 
         fun assertColumnOrder(tableName: String, expectNextVersion: Boolean) {

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/ReadFeaturesByTagsTest.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/ReadFeaturesByTagsTest.kt
@@ -49,26 +49,30 @@ class ReadFeaturesByTagsTest : PgTestBase() {
         assertEquals(0, featuresWithFooTag.size)
     }
 
+    /**
+     * The default tags member is a [naksha.model.objects.MemberType.SET]: the tags array is stored
+     * unmodified, the values are never split into key/value pairs. Therefore only full elements can
+     * be matched — `TagExists("fullelem")` does not find a feature tagged `["fullelem=bar"]`.
+     */
     @Test
-    fun shouldReturnFeaturesWithStringValue() {
+    fun shouldMatchOnlyFullElements() {
         // Given:
-        val inputFeature = randomFeatureWithTags("foo=bar")
+        val inputFeature = randomFeatureWithTags("fullelem=bar")
 
         // When:
         insertFeature(feature = inputFeature)
 
-        // And:
-        val featuresWithFooTag = executeTagsQuery(
-            TagValueIsString(name = "foo", value = "bar")
-        ).features
+        // Then: the full element matches.
+        val byFullElement = executeTagsQuery(TagExists("fullelem=bar")).features
+        assertEquals(1, byFullElement.size)
+        assertEquals(inputFeature.id, byFullElement[0]!!.id)
 
-        // Then:
-        assertEquals(1, featuresWithFooTag.size)
-        assertEquals(inputFeature.id, featuresWithFooTag[0]!!.id)
+        // And: the key alone does not (the tag is not split).
+        assertTrue(executeTagsQuery(TagExists("fullelem")).features.isEmpty())
     }
 
     @Test
-    fun shouldReturnFeaturesByBoolean(){
+    fun shouldReturnFeaturesBySetContainment() {
         // Given:
         val enabledFeatureA = randomFeatureWithTags("flag:=true")
         val enabledFeatureB = randomFeatureWithTags("flag:=true")
@@ -79,7 +83,7 @@ class ReadFeaturesByTagsTest : PgTestBase() {
 
         // And:
         val enabledFeatures = executeTagsQuery(
-            TagValueIsBool(name = "flag", value = true)
+            TagSetContains("flag:=true")
         ).features
 
         // Then:
@@ -89,61 +93,20 @@ class ReadFeaturesByTagsTest : PgTestBase() {
     }
 
     @Test
-    fun shouldReturnFeaturesByTagRegex() {
-        // Given:
-        val featureFrom2024 = randomFeatureWithTags("year=2024")
-        val featureFrom2030 = randomFeatureWithTags("year=2030")
+    fun shouldPreserveTagOrderOnReadBack() {
+        // Given: tags in an order that map-based storage would not preserve.
+        val inputFeature = randomFeatureWithTags("zulu", "alpha", "mike", "bravo")
 
         // When:
-        insertFeatures(featureFrom2024, featureFrom2030)
+        insertFeature(feature = inputFeature)
 
         // And:
-        val featuresFromThisDecade = executeTagsQuery(
-            TagValueMatches(name = "year", regex = "202[0-9]")
-        ).features
+        val readFeatures = executeTagsQuery(TagExists("zulu")).features
 
-        // Then:
-        assertEquals(1, featuresFromThisDecade.size)
-        assertEquals(featureFrom2024.id, featuresFromThisDecade[0]!!.id)
-    }
-
-    @Test
-    fun shouldReturnFeaturesWithDoubleValue() {
-        // Given:
-        val inputFeatures = listOf(
-            randomFeatureWithTags("some_number:=1").apply { id = "one" },
-            randomFeatureWithTags("some_number:=5").apply { id = "five" },
-        )
-
-        // When:
-        insertFeatures(inputFeatures)
-
-        // And:
-        val featuresGt2 = executeTagsQuery(
-            TagValueIsDouble("some_number", DoubleOp.GT, 1.0)
-        ).features
-
-        // Then:
-        assertEquals(1, featuresGt2.size)
-        assertEquals("five", featuresGt2[0]!!.id)
-
-        // When
-        val featuresLte5 = executeTagsQuery(
-            TagValueIsDouble("some_number", DoubleOp.LTE, 5.0)
-        ).features
-
-        // Then:
-        assertEquals(2, featuresLte5.size)
-        val lte5ids = featuresLte5.map { it!!.id }
-        assertTrue(lte5ids.containsAll(listOf("one", "five")))
-
-        // When:
-        val featuresEq6 = executeTagsQuery(
-            TagValueIsDouble("some_number", DoubleOp.EQ, 6.0)
-        ).features
-
-        // Then:
-        assertTrue(featuresEq6.isEmpty())
+        // Then: the set guarantees the exact element order given at write time.
+        assertEquals(1, readFeatures.size)
+        val readTags = readFeatures[0]!!.properties.xyz.tags
+        assertEquals(listOf("zulu", "alpha", "mike", "bravo"), readTags.filterNotNull())
     }
 
     @Test
@@ -158,7 +121,7 @@ class ReadFeaturesByTagsTest : PgTestBase() {
             "is_active:=true",
         )
         val inactiveJohn = randomFeatureWithTags(
-            "username=john_bar",
+            "username=john_doe",
             "is_active:=false",
         )
         val oldAdmin = randomFeatureWithTags(
@@ -171,24 +134,47 @@ class ReadFeaturesByTagsTest : PgTestBase() {
         insertFeatures(activeJohn, activeNick, inactiveJohn, oldAdmin, invalidUserWithoutId)
 
         // When:
-        val activeJohnsOrAdmin = TagOr(
+        val activeJohnOrAdmin = TagOr(
             TagAnd(
-                TagValueMatches(name = "username", regex = "john.+"),
-                TagValueIsBool(name = "is_active", value = true)
+                TagExists("username=john_doe"),
+                TagSetContains("is_active:=true")
             ),
-            TagValueIsString(name = "role", value = "admin")
+            TagSetContains("role=admin")
         )
-        val features = executeTagsQuery(activeJohnsOrAdmin).features
+        val features = executeTagsQuery(activeJohnOrAdmin).features
 
         // Then:
         assertEquals(2, features.size)
         val featureIds = features.map { it!!.id }
-        featureIds.containsAll(
-            listOf(
-                activeJohn.id,
-                oldAdmin.id
-            )
-        )
+        assertTrue(featureIds.containsAll(listOf(activeJohn.id, oldAdmin.id)))
+    }
+
+    @Test
+    fun shouldReturnFeaturesForAllOfTagSet() {
+        // Given:
+        val taggedBoth = randomFeatureWithTags("seta", "setb")
+        val taggedFoo = randomFeatureWithTags("seta")
+        val taggedBar = randomFeatureWithTags("setb")
+
+        // When:
+        insertFeatures(taggedBoth, taggedFoo, taggedBar)
+
+        // And: TagAnd of pure TagExists uses the `?&` (jsonb_exists_all) operator.
+        val withBoth = executeTagsQuery(
+            TagAnd(TagExists("seta"), TagExists("setb"))
+        ).features
+
+        // Then:
+        assertEquals(1, withBoth.size)
+        assertEquals(taggedBoth.id, withBoth[0]!!.id)
+
+        // And: TagOr of pure TagExists uses the `?|` (jsonb_exists_any) operator.
+        val withAny = executeTagsQuery(
+            TagOr(TagExists("seta"), TagExists("setb"))
+        ).features
+
+        // Then:
+        assertEquals(3, withAny.size)
     }
 
     @Test


### PR DESCRIPTION
- new MemberType.SET, IndexType.SET: jsonb array, GIN index, order preserved.
-  no key/value splitting, entries are in `key=value` format
  - SET is the default format for tag members
  - tag searches work on SETs as well (TagOr etc.), added
  TagSetContains for typed element containment with `@>`  